### PR TITLE
Fix pagination client-side error on page navigation

### DIFF
--- a/src/components/Pagination/index.js
+++ b/src/components/Pagination/index.js
@@ -40,7 +40,7 @@ const Pagination = (props) => {
                     </li>
                 );
             })}
-            <li className={`${styles.paginationItem} ${currentPage === lastPage ? styles.disabled : ""}`} onClick={currentPage === lastPage ? null : onNext}>
+            <li className={`${styles.paginationItem} ${currentPage === lastPage ? styles.disabled : ""}`} onClick={currentPage === lastPage ? undefined : onNext}>
                 <div className={`${styles.arrow} ${styles.right}`} />
             </li>
         </ul>

--- a/src/widgets/JobList/index.jsx
+++ b/src/widgets/JobList/index.jsx
@@ -80,13 +80,18 @@ const JobList = ({ jobData }) => {
     const getJoblistingData = async (params) => {
         setLoaderStatus(true);
         const size = 10;
-        const res = await getJobListing(params, pageno, size);
+        try {
+            const res = await getJobListing(params, pageno, size);
 
-        if (!!res && Array.isArray(res?.data)) {
-            setTotalJobCount(res?.totalCount);
+            if (!!res && Array.isArray(res?.data)) {
+                setTotalJobCount(res?.totalCount);
+                setJobdata(res?.data);
+            }
+        } catch (error) {
+            console.error("Error fetching job listing:", error);
+        } finally {
             setLoaderStatus(false);
             setShowMoreClicked(false);
-            setJobdata(res?.data);
         }
     };
 


### PR DESCRIPTION
## Summary
- Add try-catch error handling in `getJoblistingData` to prevent unhandled promise rejections from crashing the page when client-side API calls fail on page 2+
- Move `setLoaderStatus(false)` to `finally` block so the UI never gets stuck in infinite loading state
- Fix `onClick={null}` to `onClick={undefined}` on pagination arrow to avoid invalid event handler type

## Test plan
- [ ] Click page 2 on the jobs listing page — should load without client-side error
- [ ] Simulate a network failure on page navigation — should show previous data instead of crashing
- [ ] Verify pagination arrows work correctly on first and last pages

https://claude.ai/code/session_01BCNRDAnWtTp3pguzRi5PmE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Pagination "next" button now properly handles disabled state.
  * Job listing fetch prevents invalid data from being displayed when errors occur.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->