### PR TITLE
Redesign LinkedIn Search Builder with Code Studio UI

### DIFF
--- a/src/components/LinkedInSearch/ActiveFiltersBar.jsx
+++ b/src/components/LinkedInSearch/ActiveFiltersBar.jsx
@@ -1,0 +1,125 @@
+import { motion, AnimatePresence } from "framer-motion";
+import { X } from "lucide-react";
+import {
+  TIME_POSTED_LABELS,
+  SORT_BY_LABELS,
+  WORK_MODE_LABELS,
+  JOB_TYPE_LABELS,
+  EXPERIENCE_LEVEL_LABELS,
+  CONNECTION_DEGREE_LABELS,
+} from "./lib/linkedin-params";
+
+const LABEL_MAPS = {
+  timePosted: TIME_POSTED_LABELS,
+  sortBy: SORT_BY_LABELS,
+  workMode: WORK_MODE_LABELS,
+  jobType: JOB_TYPE_LABELS,
+  experienceLevel: EXPERIENCE_LEVEL_LABELS,
+  connectionDegree: CONNECTION_DEGREE_LABELS,
+};
+
+function getActiveChips(filters, tab) {
+  const chips = [];
+
+  if (tab === "referral") {
+    if (filters.company)
+      chips.push({ key: "company", label: filters.company, value: filters.company });
+    if (filters.role)
+      chips.push({ key: "role", label: filters.role, value: filters.role });
+    if (filters.location)
+      chips.push({ key: "location", label: filters.location, value: filters.location });
+    filters.connectionDegree?.forEach((v) => {
+      chips.push({
+        key: "connectionDegree",
+        label: CONNECTION_DEGREE_LABELS[v] || v,
+        value: v,
+      });
+    });
+    return chips;
+  }
+
+  if (filters.keywords)
+    chips.push({ key: "keywords", label: filters.keywords, value: filters.keywords });
+  if (filters.location)
+    chips.push({ key: "location", label: filters.location, value: filters.location });
+  if (filters.timePosted)
+    chips.push({
+      key: "timePosted",
+      label: TIME_POSTED_LABELS[filters.timePosted] || filters.timePosted,
+      value: filters.timePosted,
+    });
+  if (filters.sortBy)
+    chips.push({
+      key: "sortBy",
+      label: SORT_BY_LABELS[filters.sortBy] || filters.sortBy,
+      value: filters.sortBy,
+    });
+
+  const arrayFields = ["workMode", "jobType", "experienceLevel"];
+  arrayFields.forEach((field) => {
+    filters[field]?.forEach((v) => {
+      chips.push({
+        key: field,
+        label: LABEL_MAPS[field]?.[v] || v,
+        value: v,
+      });
+    });
+  });
+
+  if (filters.easyApply)
+    chips.push({ key: "easyApply", label: "Easy Apply", value: true });
+  if (filters.minSalary)
+    chips.push({
+      key: "minSalary",
+      label: `Min ${filters.salaryCurrency} ${filters.minSalary}`,
+      value: filters.minSalary,
+    });
+
+  return chips;
+}
+
+const ActiveFiltersBar = ({ filters, tab, onRemoveFilter, onClearAll }) => {
+  const chips = getActiveChips(filters, tab);
+
+  if (!chips.length) return null;
+
+  return (
+    <div className="flex items-center gap-2 overflow-x-auto pb-1 no-scrollbar">
+      <span className="text-[11px] font-dm font-medium text-gray-400 uppercase tracking-wider whitespace-nowrap flex-shrink-0">
+        Active
+      </span>
+      <AnimatePresence mode="popLayout">
+        {chips.map((chip) => (
+          <motion.span
+            key={`${chip.key}-${chip.value}`}
+            layout
+            initial={{ opacity: 0, scale: 0.8 }}
+            animate={{ opacity: 1, scale: 1 }}
+            exit={{ opacity: 0, scale: 0.8 }}
+            transition={{ duration: 0.15 }}
+            className="inline-flex items-center gap-1 px-2.5 py-1 rounded-full text-xs font-dm font-medium bg-primary/10 text-primary whitespace-nowrap flex-shrink-0"
+          >
+            {chip.label}
+            <button
+              type="button"
+              onClick={() => onRemoveFilter(chip.key, chip.value)}
+              className="ml-0.5 hover:text-primary-hover cursor-pointer"
+              aria-label={`Remove ${chip.label} filter`}
+            >
+              <X size={12} />
+            </button>
+          </motion.span>
+        ))}
+      </AnimatePresence>
+      <button
+        type="button"
+        onClick={onClearAll}
+        className="text-[11px] font-dm font-medium text-gray-400 hover:text-primary whitespace-nowrap flex-shrink-0 cursor-pointer uppercase tracking-wider"
+      >
+        Clear all
+      </button>
+    </div>
+  );
+};
+
+export default ActiveFiltersBar;

--- a/src/components/LinkedInSearch/FilterChip.jsx
+++ b/src/components/LinkedInSearch/FilterChip.jsx
@@ -1,0 +1,31 @@
+import { motion } from "framer-motion";
+
+const FilterChip = ({ label, selected, onClick, size = "md" }) => {
+  const sizeClasses =
+    size === "sm"
+      ? "px-3 py-1 text-xs min-h-[32px]"
+      : "px-3.5 py-1.5 text-sm min-h-[36px] md:min-h-[32px]";
+
+  return (
+    <motion.button
+      type="button"
+      onClick={onClick}
+      whileTap={{ scale: 0.95 }}
+      className={`
+        inline-flex items-center rounded-full font-dm font-medium transition-all duration-150 cursor-pointer select-none
+        focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2
+        ${sizeClasses}
+        ${
+          selected
+            ? "bg-primary text-white shadow-[inset_0_1px_0_rgba(255,255,255,0.15)] border border-primary hover:bg-primary-hover"
+            : "bg-white border border-gray-200 text-gray-700 hover:border-primary/40 hover:text-primary"
+        }
+      `}
+      aria-pressed={selected}
+    >
+      {label}
+    </motion.button>
+  );
+};
+
+export default FilterChip;

--- a/src/components/LinkedInSearch/FilterSection.jsx
+++ b/src/components/LinkedInSearch/FilterSection.jsx
@@ -1,0 +1,53 @@
+import { useState } from "react";
+import { motion, AnimatePresence } from "framer-motion";
+import { ChevronDown } from "lucide-react";
+
+const FilterSection = ({
+  title,
+  icon: Icon,
+  children,
+  defaultOpen = true,
+  tier = 1,
+}) => {
+  const [open, setOpen] = useState(tier === 1 ? defaultOpen : false);
+
+  return (
+    <div className="py-4 first:pt-0 last:pb-0 border-b border-gray-100 last:border-b-0">
+      <button
+        type="button"
+        onClick={() => setOpen(!open)}
+        className="w-full flex items-center justify-between text-left cursor-pointer group focus:outline-none"
+        aria-expanded={open}
+      >
+        <div className="flex items-center gap-2">
+          {Icon && <Icon size={15} className="text-gray-400 group-hover:text-primary transition-colors" />}
+          <span className="font-dm font-semibold text-[13px] uppercase tracking-wider text-gray-500 group-hover:text-gray-700 transition-colors">
+            {title}
+          </span>
+        </div>
+        <motion.div
+          animate={{ rotate: open ? 180 : 0 }}
+          transition={{ duration: 0.2 }}
+        >
+          <ChevronDown size={14} className="text-gray-400" />
+        </motion.div>
+      </button>
+
+      <AnimatePresence initial={false}>
+        {open && (
+          <motion.div
+            initial={{ height: 0, opacity: 0 }}
+            animate={{ height: "auto", opacity: 1 }}
+            exit={{ height: 0, opacity: 0 }}
+            transition={{ duration: 0.2, ease: "easeInOut" }}
+            className="overflow-hidden"
+          >
+            <div className="pt-3">{children}</div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </div>
+  );
+};
+
+export default FilterSection;

--- a/src/components/LinkedInSearch/HumanReadableSummary.jsx
+++ b/src/components/LinkedInSearch/HumanReadableSummary.jsx
@@ -1,0 +1,29 @@
+import { buildHumanReadableSummary } from "./lib/url-builder";
+
+const HumanReadableSummary = ({ filters, tab }) => {
+  const summary = buildHumanReadableSummary(filters, tab);
+
+  if (!summary) return null;
+
+  const parts = summary.split(/(\*\*[^*]+\*\*)/g);
+  const rendered = parts.map((part, i) => {
+    if (part.startsWith("**") && part.endsWith("**")) {
+      return (
+        <strong key={i} className="text-white font-semibold">
+          {part.slice(2, -2)}
+        </strong>
+      );
+    }
+    return <span key={i}>{part}</span>;
+  });
+
+  return (
+    <div className="px-4 py-3 rounded-lg bg-white/[0.06] border border-white/10">
+      <p className="font-dm text-sm text-gray-300 leading-relaxed italic">
+        {rendered}
+      </p>
+    </div>
+  );
+};
+
+export default HumanReadableSummary;

--- a/src/components/LinkedInSearch/ReferralFinder.jsx
+++ b/src/components/LinkedInSearch/ReferralFinder.jsx
@@ -1,0 +1,134 @@
+import { useState } from "react";
+import { motion, AnimatePresence } from "framer-motion";
+import {
+  Building2,
+  UserSearch,
+  Users,
+  MapPin,
+  ChevronDown,
+  Info,
+} from "lucide-react";
+import FilterSection from "./FilterSection";
+import FilterChip from "./FilterChip";
+import { CONNECTION_DEGREE } from "./lib/linkedin-params";
+
+const inputClasses =
+  "w-full px-3 py-2.5 text-sm font-dm rounded-lg border border-gray-200 bg-white focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/10 placeholder:text-gray-400 transition-all";
+
+const ReferralFinder = ({ filters, dispatch }) => {
+  const [showHowItWorks, setShowHowItWorks] = useState(false);
+
+  return (
+    <div className="space-y-0">
+      <div className="bg-white rounded-xl shadow-card p-5">
+        <FilterSection title="Company" icon={Building2} defaultOpen={true}>
+          <input
+            type="text"
+            value={filters.company}
+            onChange={(e) =>
+              dispatch({ type: "SET_FILTER", key: "company", value: e.target.value })
+            }
+            placeholder="e.g. Google, Microsoft, Razorpay..."
+            className={inputClasses}
+            aria-label="Company name"
+          />
+        </FilterSection>
+
+        <FilterSection title="Role / Title" icon={UserSearch} defaultOpen={true}>
+          <input
+            type="text"
+            value={filters.role}
+            onChange={(e) =>
+              dispatch({ type: "SET_FILTER", key: "role", value: e.target.value })
+            }
+            placeholder="e.g. Software Engineer, HR, Recruiter..."
+            className={inputClasses}
+            aria-label="Role or title"
+          />
+        </FilterSection>
+
+        <FilterSection title="Connection Degree" icon={Users} defaultOpen={true}>
+          <div className="flex flex-wrap gap-1.5">
+            {Object.entries(CONNECTION_DEGREE).map(([label, value]) => (
+              <FilterChip
+                key={value}
+                label={`${label} connections`}
+                selected={filters.connectionDegree.includes(value)}
+                onClick={() =>
+                  dispatch({ type: "TOGGLE_CHIP", key: "connectionDegree", value })
+                }
+              />
+            ))}
+          </div>
+        </FilterSection>
+
+        <FilterSection title="Location" icon={MapPin} defaultOpen={true}>
+          <input
+            type="text"
+            value={filters.location}
+            onChange={(e) =>
+              dispatch({ type: "SET_FILTER", key: "location", value: e.target.value })
+            }
+            placeholder="e.g. Bangalore, India..."
+            className={inputClasses}
+            aria-label="Location"
+          />
+        </FilterSection>
+      </div>
+
+      {/* How Referral Finder Works */}
+      <div className="mt-3 bg-white rounded-xl shadow-card overflow-hidden">
+        <button
+          type="button"
+          onClick={() => setShowHowItWorks(!showHowItWorks)}
+          className="w-full flex items-center justify-between px-5 py-3.5 text-left cursor-pointer focus:outline-none group"
+          aria-expanded={showHowItWorks}
+        >
+          <div className="flex items-center gap-2">
+            <Info size={15} className="text-primary" />
+            <span className="font-dm font-semibold text-[13px] uppercase tracking-wider text-gray-500 group-hover:text-gray-700 transition-colors">
+              How it works
+            </span>
+          </div>
+          <motion.div
+            animate={{ rotate: showHowItWorks ? 180 : 0 }}
+            transition={{ duration: 0.2 }}
+          >
+            <ChevronDown size={14} className="text-gray-400" />
+          </motion.div>
+        </button>
+
+        <AnimatePresence>
+          {showHowItWorks && (
+            <motion.div
+              initial={{ height: 0, opacity: 0 }}
+              animate={{ height: "auto", opacity: 1 }}
+              exit={{ height: 0, opacity: 0 }}
+              transition={{ duration: 0.2 }}
+              className="overflow-hidden"
+            >
+              <div className="px-5 pb-4 space-y-2">
+                <p className="text-sm font-dm text-gray-600 leading-relaxed">
+                  The Referral Finder builds a LinkedIn people search URL to help you find
+                  employees at a specific company who could potentially refer you.
+                </p>
+                <ol className="list-decimal list-inside text-sm font-dm text-gray-600 space-y-1.5 leading-relaxed">
+                  <li>Enter the company name and the role you want a referral for</li>
+                  <li>Select connection degree (1st degree connections are best for referrals)</li>
+                  <li>Open the generated URL in LinkedIn</li>
+                  <li>Reach out to people with a personalized message mentioning the role</li>
+                </ol>
+                <p className="text-xs font-dm text-gray-400 mt-2">
+                  Tip: Filter by 1st connections first — they are most likely to help.
+                  If none are found, try 2nd connections and ask mutual contacts for an introduction.
+                </p>
+              </div>
+            </motion.div>
+          )}
+        </AnimatePresence>
+      </div>
+    </div>
+  );
+};
+
+export default ReferralFinder;

--- a/src/components/LinkedInSearch/SearchBuilder.jsx
+++ b/src/components/LinkedInSearch/SearchBuilder.jsx
@@ -1,0 +1,300 @@
+import { useState, useRef } from "react";
+import { motion, AnimatePresence } from "framer-motion";
+import {
+  Search,
+  MapPin,
+  Clock,
+  Briefcase,
+  Building2,
+  GraduationCap,
+  Zap,
+  SlidersHorizontal,
+  IndianRupee,
+  ArrowUpDown,
+} from "lucide-react";
+import FilterSection from "./FilterSection";
+import FilterChip from "./FilterChip";
+import {
+  TIME_POSTED,
+  SORT_BY,
+  WORK_MODE,
+  JOB_TYPE,
+  EXPERIENCE_LEVEL_PRIMARY,
+  EXPERIENCE_LEVEL_SECONDARY,
+  INDIAN_LOCATIONS,
+  CURRENCIES,
+} from "./lib/linkedin-params";
+
+const inputClasses =
+  "w-full px-3 py-2.5 text-sm font-dm rounded-lg border border-gray-200 bg-white focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/10 placeholder:text-gray-400 transition-all";
+
+const SearchBuilder = ({ filters, dispatch }) => {
+  const [showMoreFilters, setShowMoreFilters] = useState(false);
+  const [customLocation, setCustomLocation] = useState("");
+  const keywordsRef = useRef(null);
+
+  SearchBuilder.keywordsRef = keywordsRef;
+
+  const handleCustomLocation = (e) => {
+    if (e.key === "Enter" && customLocation.trim()) {
+      dispatch({ type: "SET_FILTER", key: "location", value: customLocation.trim() });
+      setCustomLocation("");
+    }
+  };
+
+  const hasMoreFilters =
+    filters.workMode.length > 0 ||
+    filters.experienceLevel.length > 0 ||
+    filters.sortBy ||
+    filters.easyApply ||
+    filters.minSalary;
+
+  return (
+    <div className="bg-white rounded-xl shadow-card p-5">
+      {/* Tier 1: Always visible */}
+      <FilterSection title="Keywords" icon={Search} defaultOpen={true}>
+        <input
+          ref={keywordsRef}
+          type="text"
+          value={filters.keywords}
+          onChange={(e) =>
+            dispatch({ type: "SET_FILTER", key: "keywords", value: e.target.value })
+          }
+          placeholder="e.g. React Developer, Data Analyst, SDE..."
+          className={inputClasses}
+          aria-label="Job keywords"
+        />
+      </FilterSection>
+
+      <FilterSection title="Location" icon={MapPin} defaultOpen={true}>
+        <div className="space-y-2">
+          <div className="flex flex-wrap gap-1.5">
+            {INDIAN_LOCATIONS.map((loc) => (
+              <FilterChip
+                key={loc}
+                label={loc}
+                size="sm"
+                selected={filters.location === loc}
+                onClick={() =>
+                  dispatch({
+                    type: "SET_FILTER",
+                    key: "location",
+                    value: filters.location === loc ? "" : loc,
+                  })
+                }
+              />
+            ))}
+          </div>
+          <input
+            type="text"
+            value={customLocation}
+            onChange={(e) => setCustomLocation(e.target.value)}
+            onKeyDown={handleCustomLocation}
+            placeholder="Or type a custom location and press Enter"
+            className={inputClasses}
+            aria-label="Custom location"
+          />
+        </div>
+      </FilterSection>
+
+      <FilterSection title="Time Posted" icon={Clock} defaultOpen={true}>
+        <div className="flex flex-wrap gap-1.5">
+          {Object.entries(TIME_POSTED).map(([label, value]) => (
+            <FilterChip
+              key={value}
+              label={label}
+              size="sm"
+              selected={filters.timePosted === value}
+              onClick={() =>
+                dispatch({
+                  type: "SET_FILTER",
+                  key: "timePosted",
+                  value: filters.timePosted === value ? "" : value,
+                })
+              }
+            />
+          ))}
+        </div>
+      </FilterSection>
+
+      <FilterSection title="Job Type" icon={Briefcase} defaultOpen={true}>
+        <div className="flex flex-wrap gap-1.5">
+          {Object.entries(JOB_TYPE).map(([label, value]) => (
+            <FilterChip
+              key={value}
+              label={label}
+              size="sm"
+              selected={filters.jobType.includes(value)}
+              onClick={() =>
+                dispatch({ type: "TOGGLE_CHIP", key: "jobType", value })
+              }
+            />
+          ))}
+        </div>
+      </FilterSection>
+
+      {/* Tier 2: More Filters toggle */}
+      <div className="pt-4 border-t border-gray-100 mt-4">
+        <button
+          type="button"
+          onClick={() => setShowMoreFilters(!showMoreFilters)}
+          className="w-full flex items-center justify-center gap-2 py-2 text-[13px] font-dm font-semibold text-primary hover:text-primary-hover transition-colors cursor-pointer rounded-lg focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 uppercase tracking-wider"
+        >
+          <SlidersHorizontal size={13} />
+          {showMoreFilters ? "Less filters" : "More filters"}
+          {hasMoreFilters && !showMoreFilters && (
+            <span className="inline-flex items-center justify-center w-5 h-5 rounded-full bg-primary text-white text-[10px] font-bold">
+              {[
+                filters.workMode.length,
+                filters.experienceLevel.length,
+                filters.sortBy ? 1 : 0,
+                filters.easyApply ? 1 : 0,
+                filters.minSalary ? 1 : 0,
+              ].reduce((a, b) => a + b, 0)}
+            </span>
+          )}
+        </button>
+      </div>
+
+      <AnimatePresence>
+        {showMoreFilters && (
+          <motion.div
+            initial={{ height: 0, opacity: 0 }}
+            animate={{ height: "auto", opacity: 1 }}
+            exit={{ height: 0, opacity: 0 }}
+            transition={{ duration: 0.25 }}
+            className="overflow-hidden"
+          >
+            <FilterSection title="Work Mode" icon={Building2} tier={2} defaultOpen={true}>
+              <div className="flex flex-wrap gap-1.5">
+                {Object.entries(WORK_MODE).map(([label, value]) => (
+                  <FilterChip
+                    key={value}
+                    label={label}
+                    size="sm"
+                    selected={filters.workMode.includes(value)}
+                    onClick={() =>
+                      dispatch({ type: "TOGGLE_CHIP", key: "workMode", value })
+                    }
+                  />
+                ))}
+              </div>
+            </FilterSection>
+
+            <FilterSection title="Experience Level" icon={GraduationCap} tier={2} defaultOpen={true}>
+              <div className="space-y-2">
+                <div className="flex flex-wrap gap-1.5">
+                  {Object.entries(EXPERIENCE_LEVEL_PRIMARY).map(([label, value]) => (
+                    <FilterChip
+                      key={value}
+                      label={label}
+                      size="sm"
+                      selected={filters.experienceLevel.includes(value)}
+                      onClick={() =>
+                        dispatch({
+                          type: "TOGGLE_CHIP",
+                          key: "experienceLevel",
+                          value,
+                        })
+                      }
+                    />
+                  ))}
+                </div>
+                <div className="flex flex-wrap gap-1.5 opacity-60">
+                  {Object.entries(EXPERIENCE_LEVEL_SECONDARY).map(([label, value]) => (
+                    <FilterChip
+                      key={value}
+                      label={label}
+                      size="sm"
+                      selected={filters.experienceLevel.includes(value)}
+                      onClick={() =>
+                        dispatch({
+                          type: "TOGGLE_CHIP",
+                          key: "experienceLevel",
+                          value,
+                        })
+                      }
+                    />
+                  ))}
+                </div>
+              </div>
+            </FilterSection>
+
+            <FilterSection title="Sort By" icon={ArrowUpDown} tier={2} defaultOpen={true}>
+              <div className="flex flex-wrap gap-1.5">
+                {Object.entries(SORT_BY).map(([label, value]) => (
+                  <FilterChip
+                    key={value}
+                    label={label}
+                    size="sm"
+                    selected={filters.sortBy === value}
+                    onClick={() =>
+                      dispatch({
+                        type: "SET_FILTER",
+                        key: "sortBy",
+                        value: filters.sortBy === value ? "" : value,
+                      })
+                    }
+                  />
+                ))}
+              </div>
+            </FilterSection>
+
+            <FilterSection title="Easy Apply" icon={Zap} tier={2} defaultOpen={true}>
+              <FilterChip
+                label="Easy Apply only"
+                selected={filters.easyApply}
+                onClick={() =>
+                  dispatch({
+                    type: "SET_FILTER",
+                    key: "easyApply",
+                    value: !filters.easyApply,
+                  })
+                }
+              />
+            </FilterSection>
+
+            <FilterSection title="Minimum Salary" icon={IndianRupee} tier={2} defaultOpen={true}>
+              <div className="flex gap-2">
+                <select
+                  value={filters.salaryCurrency}
+                  onChange={(e) =>
+                    dispatch({
+                      type: "SET_FILTER",
+                      key: "salaryCurrency",
+                      value: e.target.value,
+                    })
+                  }
+                  className="px-2 py-2.5 text-sm font-dm rounded-lg border border-gray-200 bg-white focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/10"
+                  aria-label="Salary currency"
+                >
+                  {Object.keys(CURRENCIES).map((c) => (
+                    <option key={c} value={c}>
+                      {c}
+                    </option>
+                  ))}
+                </select>
+                <input
+                  type="number"
+                  value={filters.minSalary}
+                  onChange={(e) =>
+                    dispatch({
+                      type: "SET_FILTER",
+                      key: "minSalary",
+                      value: e.target.value,
+                    })
+                  }
+                  placeholder="e.g. 500000"
+                  className={`flex-1 ${inputClasses}`}
+                  aria-label="Minimum salary"
+                />
+              </div>
+            </FilterSection>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </div>
+  );
+};
+
+export default SearchBuilder;

--- a/src/components/LinkedInSearch/TemplateBar.jsx
+++ b/src/components/LinkedInSearch/TemplateBar.jsx
@@ -1,0 +1,113 @@
+import { useState } from "react";
+import { motion } from "framer-motion";
+import { Bookmark, X, Plus, Check } from "lucide-react";
+
+const TemplateBar = ({ templates, onApply, onSave, onRemove, hasActiveFilters }) => {
+  const [showSaveInput, setShowSaveInput] = useState(false);
+  const [templateName, setTemplateName] = useState("");
+
+  const handleSave = () => {
+    if (templateName.trim()) {
+      onSave(templateName.trim());
+      setTemplateName("");
+      setShowSaveInput(false);
+    }
+  };
+
+  const handleKeyDown = (e) => {
+    if (e.key === "Enter") handleSave();
+    if (e.key === "Escape") {
+      setShowSaveInput(false);
+      setTemplateName("");
+    }
+  };
+
+  return (
+    <div className="space-y-2.5">
+      <div className="flex items-center justify-between">
+        <span className="text-[11px] font-dm font-semibold text-gray-400 uppercase tracking-[0.08em]">
+          Quick Start
+        </span>
+        {hasActiveFilters && !showSaveInput && (
+          <button
+            type="button"
+            onClick={() => setShowSaveInput(true)}
+            className="inline-flex items-center gap-1 text-[11px] font-dm font-medium text-primary hover:text-primary-hover cursor-pointer uppercase tracking-wider"
+          >
+            <Plus size={11} /> Save current
+          </button>
+        )}
+      </div>
+
+      {showSaveInput && (
+        <div className="flex items-center gap-2">
+          <input
+            type="text"
+            value={templateName}
+            onChange={(e) => setTemplateName(e.target.value)}
+            onKeyDown={handleKeyDown}
+            placeholder="Template name..."
+            className="flex-1 px-3 py-1.5 text-sm font-dm rounded-full border border-gray-200 focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary/20 bg-white"
+            autoFocus
+          />
+          <button
+            type="button"
+            onClick={handleSave}
+            className="p-1.5 rounded-full text-primary hover:bg-primary/5 cursor-pointer"
+            aria-label="Save template"
+          >
+            <Check size={16} />
+          </button>
+          <button
+            type="button"
+            onClick={() => {
+              setShowSaveInput(false);
+              setTemplateName("");
+            }}
+            className="p-1.5 rounded-full text-gray-400 hover:text-gray-700 cursor-pointer"
+            aria-label="Cancel"
+          >
+            <X size={16} />
+          </button>
+        </div>
+      )}
+
+      <div className="flex gap-1.5 overflow-x-auto pb-1 no-scrollbar">
+        {templates.map((template) => (
+          <motion.button
+            key={template.id}
+            type="button"
+            whileTap={{ scale: 0.95 }}
+            onClick={() => onApply(template)}
+            className="relative group flex-shrink-0 inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-[12px] font-dm font-medium bg-gray-50 border border-gray-200 text-gray-600 hover:border-primary/30 hover:text-primary hover:bg-primary/5 transition-all duration-150 cursor-pointer focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2"
+          >
+            <Bookmark size={11} className="text-gray-400 group-hover:text-primary transition-colors" />
+            {template.name}
+            {!template.isBuiltIn && onRemove && (
+              <span
+                role="button"
+                tabIndex={0}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onRemove(template.id);
+                }}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") {
+                    e.stopPropagation();
+                    onRemove(template.id);
+                  }
+                }}
+                className="hidden group-hover:inline-flex ml-0.5 text-gray-400 hover:text-red-500"
+                aria-label={`Delete ${template.name}`}
+              >
+                <X size={11} />
+              </span>
+            )}
+          </motion.button>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default TemplateBar;

--- a/src/components/LinkedInSearch/URLPreview.jsx
+++ b/src/components/LinkedInSearch/URLPreview.jsx
@@ -1,0 +1,201 @@
+import { useState, useCallback } from "react";
+import { motion, AnimatePresence } from "framer-motion";
+import { Copy, Check, ExternalLink, Share2, Search } from "lucide-react";
+
+const URLPreview = ({ url, isEmpty, onShare }) => {
+  const [copied, setCopied] = useState(false);
+  const [copiedShare, setCopiedShare] = useState(false);
+
+  const handleCopy = useCallback(async () => {
+    try {
+      await navigator.clipboard.writeText(url);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      const ta = document.createElement("textarea");
+      ta.value = url;
+      document.body.appendChild(ta);
+      ta.select();
+      document.execCommand("copy");
+      document.body.removeChild(ta);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    }
+  }, [url]);
+
+  const handleOpen = useCallback(() => {
+    window.open(url, "_blank", "noopener,noreferrer");
+  }, [url]);
+
+  const handleShare = useCallback(async () => {
+    if (onShare) {
+      const shareUrl = onShare();
+      try {
+        await navigator.clipboard.writeText(shareUrl);
+        setCopiedShare(true);
+        setTimeout(() => setCopiedShare(false), 2000);
+      } catch {}
+    }
+  }, [onShare]);
+
+  const renderColoredURL = (rawUrl) => {
+    try {
+      const urlObj = new URL(rawUrl);
+      const base = urlObj.origin + urlObj.pathname;
+      const params = Array.from(urlObj.searchParams.entries());
+      if (!params.length) {
+        return (
+          <div className="flex">
+            <span className="select-none text-gray-600 w-8 text-right mr-3 flex-shrink-0">1</span>
+            <span className="text-gray-400">{rawUrl}</span>
+          </div>
+        );
+      }
+
+      const lines = [];
+      lines.push(
+        <div key="base" className="flex">
+          <span className="select-none text-gray-600 w-8 text-right mr-3 flex-shrink-0">1</span>
+          <span className="text-gray-500">{base}?</span>
+        </div>
+      );
+
+      params.forEach(([key, value], i) => {
+        lines.push(
+          <div key={key} className="flex">
+            <span className="select-none text-gray-600 w-8 text-right mr-3 flex-shrink-0">{i + 2}</span>
+            <span>
+              {i > 0 && <span className="text-gray-600">&amp;</span>}
+              <span className="text-blue-400 font-semibold">{key}</span>
+              <span className="text-gray-600">=</span>
+              <span className="text-amber-300">{decodeURIComponent(value)}</span>
+            </span>
+          </div>
+        );
+      });
+
+      return <div className="space-y-0.5">{lines}</div>;
+    } catch {
+      return <span className="text-gray-400 break-all">{rawUrl}</span>;
+    }
+  };
+
+  if (isEmpty) {
+    return (
+      <>
+        <div className="flex flex-col items-center justify-center py-12">
+          <div className="w-12 h-12 rounded-xl bg-white/[0.06] border border-white/10 flex items-center justify-center mb-4">
+            <Search size={20} className="text-gray-500" />
+          </div>
+          <p className="font-dm text-sm text-gray-500 text-center max-w-[200px]">
+            Start by typing a job title or pick a template
+          </p>
+        </div>
+      </>
+    );
+  }
+
+  return (
+    <>
+      {/* Desktop URL preview */}
+      <div className="hidden md:block">
+        <div className="flex items-center justify-between mb-3">
+          <span className="text-[11px] font-dm font-semibold text-gray-500 uppercase tracking-[0.08em]">
+            Generated URL
+          </span>
+          <span className="text-[11px] font-dm text-gray-600">
+            {Array.from(new URL(url).searchParams).length} params
+          </span>
+        </div>
+
+        <motion.div
+          key={url}
+          initial={{ opacity: 0.6 }}
+          animate={{ opacity: 1 }}
+          className="font-mono text-[13px] leading-relaxed p-4 bg-black/20 rounded-lg border border-white/10 overflow-x-auto no-scrollbar"
+        >
+          {renderColoredURL(url)}
+        </motion.div>
+
+        <div className="flex flex-wrap items-center gap-2 mt-4">
+          <button
+            type="button"
+            onClick={handleCopy}
+            className="inline-flex items-center gap-1.5 px-4 py-2 rounded-lg text-sm font-dm font-medium bg-blue-500 text-white hover:bg-blue-600 transition-all cursor-pointer focus:outline-none focus:ring-2 focus:ring-blue-400 focus:ring-offset-2 focus:ring-offset-[#1A1A2E]"
+          >
+            <AnimatePresence mode="wait" initial={false}>
+              {copied ? (
+                <motion.span
+                  key="check"
+                  initial={{ scale: 0 }}
+                  animate={{ scale: 1 }}
+                  exit={{ scale: 0 }}
+                  className="inline-flex items-center gap-1.5"
+                >
+                  <Check size={14} /> Copied!
+                </motion.span>
+              ) : (
+                <motion.span
+                  key="copy"
+                  initial={{ scale: 0 }}
+                  animate={{ scale: 1 }}
+                  exit={{ scale: 0 }}
+                  className="inline-flex items-center gap-1.5"
+                >
+                  <Copy size={14} /> Copy URL
+                </motion.span>
+              )}
+            </AnimatePresence>
+          </button>
+          <button
+            type="button"
+            onClick={handleOpen}
+            className="inline-flex items-center gap-1.5 px-4 py-2 rounded-lg text-sm font-dm font-medium border border-white/20 text-white/80 hover:border-white/40 hover:text-white transition-all cursor-pointer focus:outline-none focus:ring-2 focus:ring-white/30 focus:ring-offset-2 focus:ring-offset-[#1A1A2E]"
+          >
+            <ExternalLink size={14} /> Open in LinkedIn
+          </button>
+          {onShare && (
+            <button
+              type="button"
+              onClick={handleShare}
+              className="inline-flex items-center gap-1.5 px-4 py-2 rounded-lg text-sm font-dm font-medium border border-white/20 text-white/80 hover:border-white/40 hover:text-white transition-all cursor-pointer focus:outline-none focus:ring-2 focus:ring-white/30 focus:ring-offset-2 focus:ring-offset-[#1A1A2E]"
+            >
+              <Share2 size={14} />
+              {copiedShare ? "Link copied!" : "Share"}
+            </button>
+          )}
+        </div>
+      </div>
+
+      {/* Mobile sticky bottom bar */}
+      <div className="fixed bottom-0 left-0 right-0 md:hidden bg-[#1A1A2E] border-t border-white/10 p-3 z-40">
+        <div className="flex gap-2">
+          <button
+            type="button"
+            onClick={handleCopy}
+            className="flex-1 inline-flex items-center justify-center gap-1.5 py-2.5 rounded-lg text-sm font-dm font-medium bg-blue-500 text-white cursor-pointer"
+          >
+            {copied ? (
+              <>
+                <Check size={14} /> Copied!
+              </>
+            ) : (
+              <>
+                <Copy size={14} /> Copy URL
+              </>
+            )}
+          </button>
+          <button
+            type="button"
+            onClick={handleOpen}
+            className="flex-1 inline-flex items-center justify-center gap-1.5 py-2.5 rounded-lg text-sm font-dm font-medium border border-white/20 text-white/80 cursor-pointer"
+          >
+            <ExternalLink size={14} /> Open
+          </button>
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default URLPreview;

--- a/src/components/LinkedInSearch/hooks/useLinkedInURL.js
+++ b/src/components/LinkedInSearch/hooks/useLinkedInURL.js
@@ -1,0 +1,9 @@
+import { useMemo } from "react";
+import { buildJobSearchURL, buildReferralURL } from "../lib/url-builder";
+
+export default function useLinkedInURL(filters, activeTab) {
+  return useMemo(() => {
+    if (activeTab === "referral") return buildReferralURL(filters);
+    return buildJobSearchURL(filters);
+  }, [filters, activeTab]);
+}

--- a/src/components/LinkedInSearch/hooks/useTemplates.js
+++ b/src/components/LinkedInSearch/hooks/useTemplates.js
@@ -1,0 +1,59 @@
+import { useState, useEffect, useCallback } from "react";
+import { BUILT_IN_TEMPLATES } from "../lib/templates";
+
+const STORAGE_KEY = "linkedin-search-templates";
+
+function loadCustomTemplates() {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    return stored ? JSON.parse(stored) : [];
+  } catch {
+    return [];
+  }
+}
+
+export default function useTemplates() {
+  const [customTemplates, setCustomTemplates] = useState([]);
+
+  useEffect(() => {
+    setCustomTemplates(loadCustomTemplates());
+  }, []);
+
+  const persist = (templates) => {
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(templates));
+    } catch {
+      // localStorage full or unavailable
+    }
+  };
+
+  const saveTemplate = useCallback((name, filters) => {
+    const template = {
+      id: `custom-${Date.now()}`,
+      name,
+      filters: { ...filters },
+      isBuiltIn: false,
+      createdAt: Date.now(),
+    };
+    setCustomTemplates((prev) => {
+      const next = [...prev, template];
+      persist(next);
+      return next;
+    });
+  }, []);
+
+  const removeTemplate = useCallback((id) => {
+    setCustomTemplates((prev) => {
+      const next = prev.filter((t) => t.id !== id);
+      persist(next);
+      return next;
+    });
+  }, []);
+
+  return {
+    builtInTemplates: BUILT_IN_TEMPLATES,
+    customTemplates,
+    saveTemplate,
+    removeTemplate,
+  };
+}

--- a/src/components/LinkedInSearch/lib/linkedin-params.js
+++ b/src/components/LinkedInSearch/lib/linkedin-params.js
@@ -1,0 +1,102 @@
+export const TIME_POSTED = {
+  "Past 10 min": "r600",
+  "Past hour": "r3600",
+  "Past 24 hours": "r86400",
+  "Past week": "r604800",
+  "Past month": "r2592000",
+};
+
+export const SORT_BY = {
+  "Most recent": "DD",
+  "Most relevant": "R",
+};
+
+export const WORK_MODE = {
+  "On-site": "1",
+  Remote: "2",
+  Hybrid: "3",
+};
+
+export const JOB_TYPE = {
+  "Full-time": "F",
+  "Part-time": "P",
+  Contract: "C",
+  Temporary: "T",
+  Internship: "I",
+  Volunteer: "V",
+};
+
+export const EXPERIENCE_LEVEL_PRIMARY = {
+  Internship: "1",
+  "Entry level": "2",
+  Associate: "3",
+};
+
+export const EXPERIENCE_LEVEL_SECONDARY = {
+  "Mid-Senior": "4",
+  Director: "5",
+  Executive: "6",
+};
+
+export const EXPERIENCE_LEVEL = {
+  ...EXPERIENCE_LEVEL_PRIMARY,
+  ...EXPERIENCE_LEVEL_SECONDARY,
+};
+
+export const CONNECTION_DEGREE = {
+  "1st": "F",
+  "2nd": "S",
+  "3rd+": "O",
+};
+
+export const INDIAN_LOCATIONS = [
+  "Bangalore",
+  "Hyderabad",
+  "Mumbai",
+  "Pune",
+  "Delhi NCR",
+  "Chennai",
+  "Noida",
+  "Gurgaon",
+  "Remote",
+];
+
+export const CURRENCIES = {
+  INR: "INR",
+  USD: "USD",
+  EUR: "EUR",
+  GBP: "GBP",
+  CAD: "CAD",
+  AUD: "AUD",
+};
+
+export const INITIAL_JOB_FILTERS = {
+  keywords: "",
+  location: "",
+  timePosted: "",
+  sortBy: "",
+  workMode: [],
+  jobType: [],
+  experienceLevel: [],
+  easyApply: false,
+  minSalary: "",
+  salaryCurrency: "INR",
+};
+
+export const INITIAL_REFERRAL_FILTERS = {
+  company: "",
+  role: "",
+  connectionDegree: [],
+  location: "",
+};
+
+// Reverse lookups: value -> label
+const buildReverseLookup = (obj) =>
+  Object.fromEntries(Object.entries(obj).map(([k, v]) => [v, k]));
+
+export const TIME_POSTED_LABELS = buildReverseLookup(TIME_POSTED);
+export const SORT_BY_LABELS = buildReverseLookup(SORT_BY);
+export const WORK_MODE_LABELS = buildReverseLookup(WORK_MODE);
+export const JOB_TYPE_LABELS = buildReverseLookup(JOB_TYPE);
+export const EXPERIENCE_LEVEL_LABELS = buildReverseLookup(EXPERIENCE_LEVEL);
+export const CONNECTION_DEGREE_LABELS = buildReverseLookup(CONNECTION_DEGREE);

--- a/src/components/LinkedInSearch/lib/templates.js
+++ b/src/components/LinkedInSearch/lib/templates.js
@@ -1,0 +1,74 @@
+import { INITIAL_JOB_FILTERS } from "./linkedin-params";
+
+export const BUILT_IN_TEMPLATES = [
+  {
+    id: "fresher-sde-remote",
+    name: "Fresher SDE \u2014 Remote India",
+    filters: {
+      ...INITIAL_JOB_FILTERS,
+      keywords: "Software Developer",
+      location: "India",
+      experienceLevel: ["2"],
+      workMode: ["2"],
+      timePosted: "r2592000",
+    },
+    isBuiltIn: true,
+  },
+  {
+    id: "2025-batch-bangalore",
+    name: "2025 Batch \u2014 Entry Level Bangalore",
+    filters: {
+      ...INITIAL_JOB_FILTERS,
+      keywords: "2025 batch",
+      location: "Bangalore",
+      experienceLevel: ["1", "2"],
+      timePosted: "r604800",
+    },
+    isBuiltIn: true,
+  },
+  {
+    id: "internship-software",
+    name: "Internship \u2014 Software Development",
+    filters: {
+      ...INITIAL_JOB_FILTERS,
+      keywords: "Software Development",
+      jobType: ["I"],
+      timePosted: "r2592000",
+    },
+    isBuiltIn: true,
+  },
+  {
+    id: "data-analyst-hyderabad",
+    name: "Data Analyst \u2014 Fresher Hyderabad",
+    filters: {
+      ...INITIAL_JOB_FILTERS,
+      keywords: "Data Analyst",
+      location: "Hyderabad",
+      experienceLevel: ["2"],
+      timePosted: "r2592000",
+    },
+    isBuiltIn: true,
+  },
+  {
+    id: "frontend-remote",
+    name: "Frontend Developer \u2014 Remote",
+    filters: {
+      ...INITIAL_JOB_FILTERS,
+      keywords: "Frontend Developer",
+      workMode: ["2"],
+      jobType: ["F"],
+    },
+    isBuiltIn: true,
+  },
+  {
+    id: "devops-intern",
+    name: "DevOps Intern \u2014 Any Location",
+    filters: {
+      ...INITIAL_JOB_FILTERS,
+      keywords: "DevOps",
+      jobType: ["I"],
+      timePosted: "r604800",
+    },
+    isBuiltIn: true,
+  },
+];

--- a/src/components/LinkedInSearch/lib/url-builder.js
+++ b/src/components/LinkedInSearch/lib/url-builder.js
@@ -1,0 +1,101 @@
+import {
+  TIME_POSTED_LABELS,
+  WORK_MODE_LABELS,
+  JOB_TYPE_LABELS,
+  EXPERIENCE_LEVEL_LABELS,
+  CONNECTION_DEGREE_LABELS,
+} from "./linkedin-params";
+
+export function buildJobSearchURL(filters) {
+  const params = new URLSearchParams();
+
+  if (filters.keywords) params.set("keywords", filters.keywords);
+  if (filters.location) params.set("location", filters.location);
+  if (filters.timePosted) params.set("f_TPR", filters.timePosted);
+  if (filters.sortBy) params.set("sortBy", filters.sortBy);
+  if (filters.workMode.length) params.set("f_WT", filters.workMode.join(","));
+  if (filters.jobType.length) params.set("f_JT", filters.jobType.join(","));
+  if (filters.experienceLevel.length)
+    params.set("f_E", filters.experienceLevel.join(","));
+  if (filters.easyApply) params.set("f_EA", "true");
+  if (filters.minSalary) params.set("f_SB2", filters.minSalary);
+
+  const qs = params.toString();
+  return `https://www.linkedin.com/jobs/search/${qs ? "?" + qs : ""}`;
+}
+
+export function buildReferralURL(filters) {
+  const params = new URLSearchParams();
+
+  const keywordParts = [filters.company, filters.location].filter(Boolean);
+  if (keywordParts.length) params.set("keywords", keywordParts.join(" "));
+  if (filters.role) params.set("title", filters.role);
+  if (filters.connectionDegree.length) {
+    params.set("network", JSON.stringify(filters.connectionDegree));
+  }
+
+  const qs = params.toString();
+  return `https://www.linkedin.com/search/results/people/${qs ? "?" + qs : ""}`;
+}
+
+export function buildHumanReadableSummary(filters, tab) {
+  if (tab === "referral") {
+    const parts = [];
+    if (filters.company)
+      parts.push(`at **${filters.company}**`);
+    if (filters.role) parts.push(`with title **${filters.role}**`);
+    if (filters.connectionDegree.length) {
+      const degrees = filters.connectionDegree
+        .map((d) => CONNECTION_DEGREE_LABELS[d])
+        .join(", ");
+      parts.push(`in your **${degrees}** connections`);
+    }
+    if (filters.location) parts.push(`in **${filters.location}**`);
+    if (!parts.length) return "";
+    return `Finding people ${parts.join(", ")}`;
+  }
+
+  const parts = [];
+  if (filters.keywords) parts.push(`for **${filters.keywords}**`);
+  if (filters.location) parts.push(`in **${filters.location}**`);
+  if (filters.timePosted) {
+    const label = TIME_POSTED_LABELS[filters.timePosted];
+    if (label) parts.push(`posted in the **${label.toLowerCase()}**`);
+  }
+  if (filters.jobType.length) {
+    const types = filters.jobType.map((t) => JOB_TYPE_LABELS[t]).join(", ");
+    parts.push(`**${types}** positions`);
+  }
+  if (filters.workMode.length) {
+    const modes = filters.workMode.map((m) => WORK_MODE_LABELS[m]).join(", ");
+    parts.push(`**${modes}** work`);
+  }
+  if (filters.experienceLevel.length) {
+    const levels = filters.experienceLevel
+      .map((l) => EXPERIENCE_LEVEL_LABELS[l])
+      .join(", ");
+    parts.push(`**${levels}** level`);
+  }
+  if (filters.easyApply) parts.push(`with **Easy Apply**`);
+  if (filters.sortBy === "DD") parts.push(`sorted by **most recent**`);
+  if (!parts.length) return "";
+  return `Searching ${parts.join(", ")}`;
+}
+
+export function encodeFiltersToHash(filters, tab) {
+  try {
+    const data = { tab, filters };
+    return btoa(JSON.stringify(data));
+  } catch {
+    return "";
+  }
+}
+
+export function decodeFiltersFromHash(hash) {
+  try {
+    const decoded = JSON.parse(atob(hash));
+    return { tab: decoded.tab, filters: decoded.filters };
+  } catch {
+    return null;
+  }
+}

--- a/src/pages/tools/linkedin-search.js
+++ b/src/pages/tools/linkedin-search.js
@@ -1,0 +1,370 @@
+import { useState, useReducer, useEffect, useCallback, useMemo } from "react";
+import Head from "next/head";
+import Link from "next/link";
+import { motion } from "framer-motion";
+import { Briefcase, Users, ArrowRight } from "lucide-react";
+import Navbar from "@/components/Redesign/Navbar";
+import FooterNew from "@/components/Redesign/FooterNew";
+import SearchBuilder from "@/components/LinkedInSearch/SearchBuilder";
+import ReferralFinder from "@/components/LinkedInSearch/ReferralFinder";
+import ActiveFiltersBar from "@/components/LinkedInSearch/ActiveFiltersBar";
+import URLPreview from "@/components/LinkedInSearch/URLPreview";
+import TemplateBar from "@/components/LinkedInSearch/TemplateBar";
+import HumanReadableSummary from "@/components/LinkedInSearch/HumanReadableSummary";
+import useLinkedInURL from "@/components/LinkedInSearch/hooks/useLinkedInURL";
+import useTemplates from "@/components/LinkedInSearch/hooks/useTemplates";
+import {
+  INITIAL_JOB_FILTERS,
+  INITIAL_REFERRAL_FILTERS,
+} from "@/components/LinkedInSearch/lib/linkedin-params";
+import {
+  encodeFiltersToHash,
+  decodeFiltersFromHash,
+} from "@/components/LinkedInSearch/lib/url-builder";
+
+const shouldAnimate =
+  typeof window !== "undefined"
+    ? !window.matchMedia("(prefers-reduced-motion: reduce)").matches
+    : true;
+
+function jobFilterReducer(state, action) {
+  switch (action.type) {
+    case "SET_FILTER":
+      return { ...state, [action.key]: action.value };
+    case "TOGGLE_CHIP": {
+      const arr = state[action.key];
+      return {
+        ...state,
+        [action.key]: arr.includes(action.value)
+          ? arr.filter((v) => v !== action.value)
+          : [...arr, action.value],
+      };
+    }
+    case "REMOVE_FILTER": {
+      const current = state[action.key];
+      if (Array.isArray(current)) {
+        return {
+          ...state,
+          [action.key]: current.filter((v) => v !== action.value),
+        };
+      }
+      if (action.key === "easyApply") return { ...state, easyApply: false };
+      if (action.key === "minSalary") return { ...state, minSalary: "" };
+      return { ...state, [action.key]: "" };
+    }
+    case "CLEAR_ALL":
+      return { ...INITIAL_JOB_FILTERS };
+    case "APPLY_TEMPLATE":
+      return { ...action.filters };
+    default:
+      return state;
+  }
+}
+
+function referralFilterReducer(state, action) {
+  switch (action.type) {
+    case "SET_FILTER":
+      return { ...state, [action.key]: action.value };
+    case "TOGGLE_CHIP": {
+      const arr = state[action.key];
+      return {
+        ...state,
+        [action.key]: arr.includes(action.value)
+          ? arr.filter((v) => v !== action.value)
+          : [...arr, action.value],
+      };
+    }
+    case "REMOVE_FILTER": {
+      const current = state[action.key];
+      if (Array.isArray(current)) {
+        return {
+          ...state,
+          [action.key]: current.filter((v) => v !== action.value),
+        };
+      }
+      return { ...state, [action.key]: "" };
+    }
+    case "CLEAR_ALL":
+      return { ...INITIAL_REFERRAL_FILTERS };
+    default:
+      return state;
+  }
+}
+
+export default function LinkedInSearchPage() {
+  const [activeTab, setActiveTab] = useState("search");
+  const [jobFilters, jobDispatch] = useReducer(jobFilterReducer, INITIAL_JOB_FILTERS);
+  const [referralFilters, referralDispatch] = useReducer(
+    referralFilterReducer,
+    INITIAL_REFERRAL_FILTERS
+  );
+
+  const filters = activeTab === "search" ? jobFilters : referralFilters;
+  const dispatch = activeTab === "search" ? jobDispatch : referralDispatch;
+
+  const url = useLinkedInURL(filters, activeTab);
+  const { builtInTemplates, customTemplates, saveTemplate, removeTemplate } = useTemplates();
+  const allTemplates = useMemo(
+    () => [...builtInTemplates, ...customTemplates],
+    [builtInTemplates, customTemplates]
+  );
+
+  const isEmpty = useMemo(() => {
+    if (activeTab === "search") {
+      return (
+        !jobFilters.keywords &&
+        !jobFilters.location &&
+        !jobFilters.timePosted &&
+        !jobFilters.sortBy &&
+        !jobFilters.workMode.length &&
+        !jobFilters.jobType.length &&
+        !jobFilters.experienceLevel.length &&
+        !jobFilters.easyApply &&
+        !jobFilters.minSalary
+      );
+    }
+    return (
+      !referralFilters.company &&
+      !referralFilters.role &&
+      !referralFilters.connectionDegree.length &&
+      !referralFilters.location
+    );
+  }, [activeTab, jobFilters, referralFilters]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const hash = window.location.hash.slice(1);
+    if (!hash) return;
+    const decoded = decodeFiltersFromHash(hash);
+    if (!decoded) return;
+    setActiveTab(decoded.tab || "search");
+    if (decoded.tab === "referral") {
+      referralDispatch({ type: "CLEAR_ALL" });
+      Object.entries(decoded.filters).forEach(([key, value]) => {
+        referralDispatch({ type: "SET_FILTER", key, value });
+      });
+    } else {
+      jobDispatch({ type: "APPLY_TEMPLATE", filters: { ...INITIAL_JOB_FILTERS, ...decoded.filters } });
+    }
+    window.history.replaceState(null, "", window.location.pathname);
+  }, []);
+
+  useEffect(() => {
+    const handleKeyDown = (e) => {
+      if ((e.metaKey || e.ctrlKey) && e.key === "k") {
+        e.preventDefault();
+        const ref = SearchBuilder.keywordsRef;
+        if (ref?.current) ref.current.focus();
+      }
+      if ((e.metaKey || e.ctrlKey) && e.shiftKey && e.key === "C") {
+        e.preventDefault();
+        if (!isEmpty) navigator.clipboard?.writeText(url);
+      }
+    };
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [url, isEmpty]);
+
+  const handleApplyTemplate = useCallback(
+    (template) => {
+      setActiveTab("search");
+      jobDispatch({ type: "APPLY_TEMPLATE", filters: template.filters });
+    },
+    []
+  );
+
+  const handleSaveTemplate = useCallback(
+    (name) => {
+      saveTemplate(name, jobFilters);
+    },
+    [saveTemplate, jobFilters]
+  );
+
+  const handleShare = useCallback(() => {
+    const hash = encodeFiltersToHash(filters, activeTab);
+    return `${window.location.origin}${window.location.pathname}#${hash}`;
+  }, [filters, activeTab]);
+
+  const tabs = [
+    { id: "search", label: "Job Search", icon: Briefcase },
+    { id: "referral", label: "Referral Finder", icon: Users },
+  ];
+
+  const fadeUp = shouldAnimate
+    ? { initial: { opacity: 0, y: 20 }, animate: { opacity: 1, y: 0 } }
+    : { initial: {}, animate: {} };
+
+  return (
+    <>
+      <Head>
+        <title>LinkedIn Job Search URL Builder | CareersAt.Tech</title>
+        <meta
+          name="description"
+          content="Build optimized LinkedIn job search URLs with smart filters. Find jobs faster with pre-built templates for Indian freshers and early-career professionals."
+        />
+      </Head>
+
+      <Navbar />
+
+      <main
+        id="main-content"
+        className="min-h-screen pb-20 md:pb-12"
+        style={{ background: "radial-gradient(ellipse at 50% 0%, #EEF2FF 0%, #F9FAFB 70%)" }}
+      >
+        {/* Hero */}
+        <div className="max-w-content mx-auto px-4 lg:px-6 pt-24 sm:pt-28">
+          <div className="max-w-[680px] mx-auto text-center mb-10">
+            <motion.p
+              {...fadeUp}
+              transition={{ duration: 0.3 }}
+              className="text-[11px] font-dm font-semibold uppercase tracking-[0.1em] text-primary mb-5"
+            >
+              Smart Search Builder
+            </motion.p>
+            <motion.h1
+              {...fadeUp}
+              transition={{ duration: 0.3, delay: 0.05 }}
+              className="font-serif-display font-normal text-text-primary mb-5"
+              style={{ fontSize: "clamp(2.25rem, 5vw, 3rem)", lineHeight: 1.1, letterSpacing: "-0.02em" }}
+            >
+              Build your perfect
+              <br />
+              LinkedIn search.
+            </motion.h1>
+            <motion.p
+              {...fadeUp}
+              transition={{ duration: 0.3, delay: 0.15 }}
+              className="text-base font-dm text-gray-500 max-w-[480px] mx-auto mb-4 leading-relaxed"
+            >
+              Craft optimized search URLs with smart filters.
+              No sign-in required.
+            </motion.p>
+            <motion.p
+              {...fadeUp}
+              transition={{ duration: 0.3, delay: 0.25 }}
+              className="text-xs font-dm text-gray-400"
+            >
+              <kbd className="px-1.5 py-0.5 rounded border border-gray-200 bg-white text-[10px] font-mono text-gray-500">
+                {typeof navigator !== "undefined" && /Mac/.test(navigator.userAgent) ? "⌘" : "Ctrl"}+K
+              </kbd>{" "}
+              to focus search &middot;{" "}
+              <kbd className="px-1.5 py-0.5 rounded border border-gray-200 bg-white text-[10px] font-mono text-gray-500">
+                {typeof navigator !== "undefined" && /Mac/.test(navigator.userAgent) ? "⌘" : "Ctrl"}+⇧+C
+              </kbd>{" "}
+              to copy URL
+            </motion.p>
+          </div>
+        </div>
+
+        {/* Two-column workspace */}
+        <motion.div
+          {...fadeUp}
+          transition={{ duration: 0.3, delay: 0.3 }}
+          className="max-w-content mx-auto px-4 lg:px-6"
+        >
+          <div className="grid grid-cols-1 lg:grid-cols-[1fr_400px] gap-6">
+            {/* Left Column: Filters */}
+            <div>
+              {/* Tabs — underline style */}
+              <div className="flex gap-0 border-b border-gray-200 mb-5">
+                {tabs.map((tab) => (
+                  <button
+                    key={tab.id}
+                    type="button"
+                    onClick={() => setActiveTab(tab.id)}
+                    className={`relative flex items-center gap-2 px-4 py-3 text-sm font-dm font-semibold transition-colors cursor-pointer focus:outline-none ${
+                      activeTab === tab.id
+                        ? "text-primary"
+                        : "text-gray-400 hover:text-gray-700"
+                    }`}
+                  >
+                    <tab.icon size={15} />
+                    {tab.label}
+                    {activeTab === tab.id && (
+                      <motion.div
+                        layoutId="tab-underline"
+                        className="absolute bottom-0 left-0 right-0 h-[2px] bg-primary"
+                        transition={{ type: "spring", bounce: 0.15, duration: 0.4 }}
+                      />
+                    )}
+                  </button>
+                ))}
+              </div>
+
+              {/* Templates (job search only) */}
+              {activeTab === "search" && (
+                <div className="mb-4">
+                  <TemplateBar
+                    templates={allTemplates}
+                    onApply={handleApplyTemplate}
+                    onSave={handleSaveTemplate}
+                    onRemove={removeTemplate}
+                    hasActiveFilters={!isEmpty}
+                  />
+                </div>
+              )}
+
+              {/* Active Filters */}
+              {!isEmpty && (
+                <div className="mb-4">
+                  <ActiveFiltersBar
+                    filters={filters}
+                    tab={activeTab}
+                    onRemoveFilter={(key, value) =>
+                      dispatch({ type: "REMOVE_FILTER", key, value })
+                    }
+                    onClearAll={() => dispatch({ type: "CLEAR_ALL" })}
+                  />
+                </div>
+              )}
+
+              {/* Filter Content */}
+              {activeTab === "search" ? (
+                <SearchBuilder filters={jobFilters} dispatch={jobDispatch} />
+              ) : (
+                <ReferralFinder filters={referralFilters} dispatch={referralDispatch} />
+              )}
+            </div>
+
+            {/* Right Column: Dark Preview Panel */}
+            <motion.div
+              {...(shouldAnimate
+                ? { initial: { opacity: 0, y: 20, scale: 0.98 }, animate: { opacity: 1, y: 0, scale: 1 } }
+                : { initial: {}, animate: {} }
+              )}
+              transition={{ duration: 0.35, delay: 0.35 }}
+              className="lg:sticky lg:top-20 lg:self-start rounded-2xl p-6 space-y-5"
+              style={{ background: "#1A1A2E" }}
+            >
+              {/* Summary */}
+              <HumanReadableSummary filters={filters} tab={activeTab} />
+
+              {/* URL Preview */}
+              <URLPreview url={url} isEmpty={isEmpty} onShare={isEmpty ? null : handleShare} />
+
+              {/* Cross-link to CareersAt.Tech jobs */}
+              <div className="p-4 rounded-lg bg-white/[0.06] border border-white/10 text-center">
+                <p className="text-sm font-dm text-gray-400 mb-2">
+                  Also check CareersAt.Tech for verified listings
+                </p>
+                <Link
+                  href="/jobs"
+                  className="inline-flex items-center gap-1.5 text-sm font-dm font-medium text-blue-400 hover:text-blue-300 transition-colors"
+                >
+                  Browse jobs <ArrowRight size={14} />
+                </Link>
+              </div>
+
+              {/* Disclaimer */}
+              <p className="text-center text-[11px] font-dm text-gray-600">
+                Not affiliated with LinkedIn Corporation. This tool generates URLs only — no data is collected.
+              </p>
+            </motion.div>
+          </div>
+        </motion.div>
+      </main>
+
+      <FooterNew />
+    </>
+  );
+}


### PR DESCRIPTION
## Summary

Complete UI overhaul of the `/tools/linkedin-search` page with a distinctive "Code Studio" aesthetic:

- **Dark preview panel** (`#1A1A2E`) on right sidebar with line-numbered, syntax-highlighted URL display (blue param keys, amber values)
- **Instrument Serif** hero headline for editorial feel, DM Sans for all UI text
- **Radial gradient** hero background (`#F9FAFB → #EEF2FF`)
- **Underline tab switcher** replacing filled-background tabs
- **Single-card filter workspace** with open sections and dividers (no nested card-in-card)
- **Refined filter chips** with inner shadow depth on selected state
- **Orchestrated page-load animation** with staggered fadeUp reveals
- **Dark mobile sticky bar** matching the preview panel

## Test plan

- [ ] Visit `/tools/linkedin-search` and verify the new layout renders
- [ ] Type keywords and select filter chips — verify URL updates in dark panel
- [ ] Switch between Job Search and Referral Finder tabs
- [ ] Apply a template from Quick Start section
- [ ] Copy URL and Open in LinkedIn buttons work
- [ ] Test on mobile viewport — sticky bottom bar is dark themed
- [ ] Verify `prefers-reduced-motion` disables animations

https://claude.ai/code/session_01PLHT612vQ3atkM4BXFzYBX

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * **LinkedIn Smart Search Builder**: Advanced job search with filters for keywords, location, salary range, experience level, work mode, job type, and posting date
  * **Referral Finder**: Search LinkedIn referrals by company, role, location, and connection degree
  * Save and reuse custom search templates
  * Copy and share generated LinkedIn search URLs
  * Active filters display showing all applied search criteria
  * Keyboard shortcuts: Cmd/Ctrl+K to focus search, Cmd/Ctrl+Shift+C to copy URL
  * Mobile-responsive design

<!-- end of auto-generated comment: release notes by coderabbit.ai -->