### PR TITLE
Redesign LinkedIn Search Builder with Code Studio UI

### DIFF
--- a/src/components/LinkedInSearch/ActiveFiltersBar.jsx
+++ b/src/components/LinkedInSearch/ActiveFiltersBar.jsx
@@ -85,8 +85,8 @@ const ActiveFiltersBar = ({ filters, tab, onRemoveFilter, onClearAll }) => {
 
   return (
     <div className="flex items-center gap-2 overflow-x-auto pb-1 no-scrollbar">
-      <span className="text-xs font-dm text-text-tertiary whitespace-nowrap flex-shrink-0">
-        Active filters:
+      <span className="text-[11px] font-dm font-medium text-gray-400 uppercase tracking-wider whitespace-nowrap flex-shrink-0">
+        Active
       </span>
       <AnimatePresence mode="popLayout">
         {chips.map((chip) => (
@@ -97,7 +97,7 @@ const ActiveFiltersBar = ({ filters, tab, onRemoveFilter, onClearAll }) => {
             animate={{ opacity: 1, scale: 1 }}
             exit={{ opacity: 0, scale: 0.8 }}
             transition={{ duration: 0.15 }}
-            className="inline-flex items-center gap-1 px-2.5 py-1 rounded-full text-xs font-dm font-medium bg-primary-light text-primary whitespace-nowrap flex-shrink-0"
+            className="inline-flex items-center gap-1 px-2.5 py-1 rounded-full text-xs font-dm font-medium bg-primary/10 text-primary whitespace-nowrap flex-shrink-0"
           >
             {chip.label}
             <button
@@ -114,7 +114,7 @@ const ActiveFiltersBar = ({ filters, tab, onRemoveFilter, onClearAll }) => {
       <button
         type="button"
         onClick={onClearAll}
-        className="text-xs font-dm text-text-tertiary hover:text-primary whitespace-nowrap flex-shrink-0 cursor-pointer"
+        className="text-[11px] font-dm font-medium text-gray-400 hover:text-primary whitespace-nowrap flex-shrink-0 cursor-pointer uppercase tracking-wider"
       >
         Clear all
       </button>

--- a/src/components/LinkedInSearch/FilterChip.jsx
+++ b/src/components/LinkedInSearch/FilterChip.jsx
@@ -3,7 +3,7 @@ import { motion } from "framer-motion";
 const FilterChip = ({ label, selected, onClick, size = "md" }) => {
   const sizeClasses =
     size === "sm"
-      ? "px-2.5 py-1 text-xs min-h-[32px]"
+      ? "px-3 py-1 text-xs min-h-[32px]"
       : "px-3.5 py-1.5 text-sm min-h-[36px] md:min-h-[32px]";
 
   return (
@@ -12,13 +12,13 @@ const FilterChip = ({ label, selected, onClick, size = "md" }) => {
       onClick={onClick}
       whileTap={{ scale: 0.95 }}
       className={`
-        inline-flex items-center rounded-full font-dm font-medium transition-all cursor-pointer select-none
+        inline-flex items-center rounded-full font-dm font-medium transition-all duration-150 cursor-pointer select-none
         focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2
         ${sizeClasses}
         ${
           selected
-            ? "bg-primary text-white shadow-sm border border-primary hover:bg-primary-hover"
-            : "bg-card border border-border text-text-primary hover:border-primary hover:text-primary"
+            ? "bg-primary text-white shadow-[inset_0_1px_0_rgba(255,255,255,0.15)] border border-primary hover:bg-primary-hover"
+            : "bg-white border border-gray-200 text-gray-700 hover:border-primary/40 hover:text-primary"
         }
       `}
       aria-pressed={selected}

--- a/src/components/LinkedInSearch/FilterSection.jsx
+++ b/src/components/LinkedInSearch/FilterSection.jsx
@@ -12,16 +12,16 @@ const FilterSection = ({
   const [open, setOpen] = useState(tier === 1 ? defaultOpen : false);
 
   return (
-    <div className="bg-card rounded-card shadow-card border border-transparent hover:shadow-card-hover transition-shadow duration-200">
+    <div className="py-4 first:pt-0 last:pb-0 border-b border-gray-100 last:border-b-0">
       <button
         type="button"
         onClick={() => setOpen(!open)}
-        className="w-full flex items-center justify-between px-4 py-3 text-left cursor-pointer rounded-card focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2"
+        className="w-full flex items-center justify-between text-left cursor-pointer group focus:outline-none"
         aria-expanded={open}
       >
         <div className="flex items-center gap-2">
-          {Icon && <Icon size={16} className="text-text-tertiary" />}
-          <span className="font-dm font-semibold text-sm text-text-primary">
+          {Icon && <Icon size={15} className="text-gray-400 group-hover:text-primary transition-colors" />}
+          <span className="font-dm font-semibold text-[13px] uppercase tracking-wider text-gray-500 group-hover:text-gray-700 transition-colors">
             {title}
           </span>
         </div>
@@ -29,7 +29,7 @@ const FilterSection = ({
           animate={{ rotate: open ? 180 : 0 }}
           transition={{ duration: 0.2 }}
         >
-          <ChevronDown size={16} className="text-text-tertiary" />
+          <ChevronDown size={14} className="text-gray-400" />
         </motion.div>
       </button>
 
@@ -42,7 +42,7 @@ const FilterSection = ({
             transition={{ duration: 0.2, ease: "easeInOut" }}
             className="overflow-hidden"
           >
-            <div className="px-4 pb-4">{children}</div>
+            <div className="pt-3">{children}</div>
           </motion.div>
         )}
       </AnimatePresence>

--- a/src/components/LinkedInSearch/HumanReadableSummary.jsx
+++ b/src/components/LinkedInSearch/HumanReadableSummary.jsx
@@ -5,12 +5,11 @@ const HumanReadableSummary = ({ filters, tab }) => {
 
   if (!summary) return null;
 
-  // Convert **text** to <strong> elements
   const parts = summary.split(/(\*\*[^*]+\*\*)/g);
   const rendered = parts.map((part, i) => {
     if (part.startsWith("**") && part.endsWith("**")) {
       return (
-        <strong key={i} className="text-text-primary font-semibold">
+        <strong key={i} className="text-white font-semibold">
           {part.slice(2, -2)}
         </strong>
       );
@@ -19,8 +18,8 @@ const HumanReadableSummary = ({ filters, tab }) => {
   });
 
   return (
-    <div className="p-4 bg-card rounded-card shadow-card border border-border">
-      <p className="font-dm text-sm text-text-secondary leading-relaxed">
+    <div className="px-4 py-3 rounded-lg bg-white/[0.06] border border-white/10">
+      <p className="font-dm text-sm text-gray-300 leading-relaxed italic">
         {rendered}
       </p>
     </div>

--- a/src/components/LinkedInSearch/ReferralFinder.jsx
+++ b/src/components/LinkedInSearch/ReferralFinder.jsx
@@ -13,86 +13,88 @@ import FilterChip from "./FilterChip";
 import { CONNECTION_DEGREE } from "./lib/linkedin-params";
 
 const inputClasses =
-  "w-full px-3 py-2 text-sm font-dm rounded-input border border-border focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary/20 placeholder:text-text-tertiary";
+  "w-full px-3 py-2.5 text-sm font-dm rounded-lg border border-gray-200 bg-white focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/10 placeholder:text-gray-400 transition-all";
 
 const ReferralFinder = ({ filters, dispatch }) => {
   const [showHowItWorks, setShowHowItWorks] = useState(false);
 
   return (
-    <div className="space-y-3">
-      <FilterSection title="Company" icon={Building2} defaultOpen={true}>
-        <input
-          type="text"
-          value={filters.company}
-          onChange={(e) =>
-            dispatch({ type: "SET_FILTER", key: "company", value: e.target.value })
-          }
-          placeholder="e.g. Google, Microsoft, Razorpay..."
-          className={inputClasses}
-          aria-label="Company name"
-        />
-      </FilterSection>
+    <div className="space-y-0">
+      <div className="bg-white rounded-xl shadow-card p-5">
+        <FilterSection title="Company" icon={Building2} defaultOpen={true}>
+          <input
+            type="text"
+            value={filters.company}
+            onChange={(e) =>
+              dispatch({ type: "SET_FILTER", key: "company", value: e.target.value })
+            }
+            placeholder="e.g. Google, Microsoft, Razorpay..."
+            className={inputClasses}
+            aria-label="Company name"
+          />
+        </FilterSection>
 
-      <FilterSection title="Role / Title" icon={UserSearch} defaultOpen={true}>
-        <input
-          type="text"
-          value={filters.role}
-          onChange={(e) =>
-            dispatch({ type: "SET_FILTER", key: "role", value: e.target.value })
-          }
-          placeholder="e.g. Software Engineer, HR, Recruiter..."
-          className={inputClasses}
-          aria-label="Role or title"
-        />
-      </FilterSection>
+        <FilterSection title="Role / Title" icon={UserSearch} defaultOpen={true}>
+          <input
+            type="text"
+            value={filters.role}
+            onChange={(e) =>
+              dispatch({ type: "SET_FILTER", key: "role", value: e.target.value })
+            }
+            placeholder="e.g. Software Engineer, HR, Recruiter..."
+            className={inputClasses}
+            aria-label="Role or title"
+          />
+        </FilterSection>
 
-      <FilterSection title="Connection Degree" icon={Users} defaultOpen={true}>
-        <div className="flex flex-wrap gap-1.5">
-          {Object.entries(CONNECTION_DEGREE).map(([label, value]) => (
-            <FilterChip
-              key={value}
-              label={`${label} connections`}
-              selected={filters.connectionDegree.includes(value)}
-              onClick={() =>
-                dispatch({ type: "TOGGLE_CHIP", key: "connectionDegree", value })
-              }
-            />
-          ))}
-        </div>
-      </FilterSection>
+        <FilterSection title="Connection Degree" icon={Users} defaultOpen={true}>
+          <div className="flex flex-wrap gap-1.5">
+            {Object.entries(CONNECTION_DEGREE).map(([label, value]) => (
+              <FilterChip
+                key={value}
+                label={`${label} connections`}
+                selected={filters.connectionDegree.includes(value)}
+                onClick={() =>
+                  dispatch({ type: "TOGGLE_CHIP", key: "connectionDegree", value })
+                }
+              />
+            ))}
+          </div>
+        </FilterSection>
 
-      <FilterSection title="Location" icon={MapPin} defaultOpen={true}>
-        <input
-          type="text"
-          value={filters.location}
-          onChange={(e) =>
-            dispatch({ type: "SET_FILTER", key: "location", value: e.target.value })
-          }
-          placeholder="e.g. Bangalore, India..."
-          className={inputClasses}
-          aria-label="Location"
-        />
-      </FilterSection>
+        <FilterSection title="Location" icon={MapPin} defaultOpen={true}>
+          <input
+            type="text"
+            value={filters.location}
+            onChange={(e) =>
+              dispatch({ type: "SET_FILTER", key: "location", value: e.target.value })
+            }
+            placeholder="e.g. Bangalore, India..."
+            className={inputClasses}
+            aria-label="Location"
+          />
+        </FilterSection>
+      </div>
 
       {/* How Referral Finder Works */}
-      <div className="bg-card rounded-card shadow-card border border-transparent overflow-hidden">
+      <div className="mt-3 bg-white rounded-xl shadow-card overflow-hidden">
         <button
           type="button"
           onClick={() => setShowHowItWorks(!showHowItWorks)}
-          className="w-full flex items-center justify-between px-4 py-3 text-left cursor-pointer rounded-card focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2"
+          className="w-full flex items-center justify-between px-5 py-3.5 text-left cursor-pointer focus:outline-none group"
           aria-expanded={showHowItWorks}
         >
           <div className="flex items-center gap-2">
-            <Info size={16} className="text-primary" />
-            <span className="font-dm font-semibold text-sm text-text-primary">
-              How Referral Finder Works
+            <Info size={15} className="text-primary" />
+            <span className="font-dm font-semibold text-[13px] uppercase tracking-wider text-gray-500 group-hover:text-gray-700 transition-colors">
+              How it works
             </span>
           </div>
           <motion.div
             animate={{ rotate: showHowItWorks ? 180 : 0 }}
             transition={{ duration: 0.2 }}
           >
-            <ChevronDown size={16} className="text-text-tertiary" />
+            <ChevronDown size={14} className="text-gray-400" />
           </motion.div>
         </button>
 
@@ -105,18 +107,18 @@ const ReferralFinder = ({ filters, dispatch }) => {
               transition={{ duration: 0.2 }}
               className="overflow-hidden"
             >
-              <div className="px-4 pb-4 space-y-2">
-                <p className="text-sm font-dm text-text-secondary leading-relaxed">
+              <div className="px-5 pb-4 space-y-2">
+                <p className="text-sm font-dm text-gray-600 leading-relaxed">
                   The Referral Finder builds a LinkedIn people search URL to help you find
                   employees at a specific company who could potentially refer you.
                 </p>
-                <ol className="list-decimal list-inside text-sm font-dm text-text-secondary space-y-1.5 leading-relaxed">
+                <ol className="list-decimal list-inside text-sm font-dm text-gray-600 space-y-1.5 leading-relaxed">
                   <li>Enter the company name and the role you want a referral for</li>
                   <li>Select connection degree (1st degree connections are best for referrals)</li>
                   <li>Open the generated URL in LinkedIn</li>
                   <li>Reach out to people with a personalized message mentioning the role</li>
                 </ol>
-                <p className="text-xs font-dm text-text-tertiary mt-2">
+                <p className="text-xs font-dm text-gray-400 mt-2">
                   Tip: Filter by 1st connections first — they are most likely to help.
                   If none are found, try 2nd connections and ask mutual contacts for an introduction.
                 </p>

--- a/src/components/LinkedInSearch/SearchBuilder.jsx
+++ b/src/components/LinkedInSearch/SearchBuilder.jsx
@@ -26,14 +26,13 @@ import {
 } from "./lib/linkedin-params";
 
 const inputClasses =
-  "w-full px-3 py-2 text-sm font-dm rounded-input border border-border focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary/20 placeholder:text-text-tertiary";
+  "w-full px-3 py-2.5 text-sm font-dm rounded-lg border border-gray-200 bg-white focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/10 placeholder:text-gray-400 transition-all";
 
 const SearchBuilder = ({ filters, dispatch }) => {
   const [showMoreFilters, setShowMoreFilters] = useState(false);
   const [customLocation, setCustomLocation] = useState("");
   const keywordsRef = useRef(null);
 
-  // Expose ref for keyboard shortcut
   SearchBuilder.keywordsRef = keywordsRef;
 
   const handleCustomLocation = (e) => {
@@ -51,7 +50,7 @@ const SearchBuilder = ({ filters, dispatch }) => {
     filters.minSalary;
 
   return (
-    <div className="space-y-3">
+    <div className="bg-white rounded-xl shadow-card p-5">
       {/* Tier 1: Always visible */}
       <FilterSection title="Keywords" icon={Search} defaultOpen={true}>
         <input
@@ -134,26 +133,28 @@ const SearchBuilder = ({ filters, dispatch }) => {
         </div>
       </FilterSection>
 
-      {/* Tier 2: More Filters */}
-      <button
-        type="button"
-        onClick={() => setShowMoreFilters(!showMoreFilters)}
-        className="w-full flex items-center justify-center gap-2 py-2.5 text-sm font-dm font-medium text-primary hover:text-primary-hover transition-colors cursor-pointer rounded-button focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2"
-      >
-        <SlidersHorizontal size={14} />
-        {showMoreFilters ? "Less filters" : "More filters"}
-        {hasMoreFilters && !showMoreFilters && (
-          <span className="inline-flex items-center justify-center w-5 h-5 rounded-full bg-primary text-white text-[10px] font-bold">
-            {[
-              filters.workMode.length,
-              filters.experienceLevel.length,
-              filters.sortBy ? 1 : 0,
-              filters.easyApply ? 1 : 0,
-              filters.minSalary ? 1 : 0,
-            ].reduce((a, b) => a + b, 0)}
-          </span>
-        )}
-      </button>
+      {/* Tier 2: More Filters toggle */}
+      <div className="pt-4 border-t border-gray-100 mt-4">
+        <button
+          type="button"
+          onClick={() => setShowMoreFilters(!showMoreFilters)}
+          className="w-full flex items-center justify-center gap-2 py-2 text-[13px] font-dm font-semibold text-primary hover:text-primary-hover transition-colors cursor-pointer rounded-lg focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 uppercase tracking-wider"
+        >
+          <SlidersHorizontal size={13} />
+          {showMoreFilters ? "Less filters" : "More filters"}
+          {hasMoreFilters && !showMoreFilters && (
+            <span className="inline-flex items-center justify-center w-5 h-5 rounded-full bg-primary text-white text-[10px] font-bold">
+              {[
+                filters.workMode.length,
+                filters.experienceLevel.length,
+                filters.sortBy ? 1 : 0,
+                filters.easyApply ? 1 : 0,
+                filters.minSalary ? 1 : 0,
+              ].reduce((a, b) => a + b, 0)}
+            </span>
+          )}
+        </button>
+      </div>
 
       <AnimatePresence>
         {showMoreFilters && (
@@ -162,7 +163,7 @@ const SearchBuilder = ({ filters, dispatch }) => {
             animate={{ height: "auto", opacity: 1 }}
             exit={{ height: 0, opacity: 0 }}
             transition={{ duration: 0.25 }}
-            className="overflow-hidden space-y-3"
+            className="overflow-hidden"
           >
             <FilterSection title="Work Mode" icon={Building2} tier={2} defaultOpen={true}>
               <div className="flex flex-wrap gap-1.5">
@@ -199,7 +200,7 @@ const SearchBuilder = ({ filters, dispatch }) => {
                     />
                   ))}
                 </div>
-                <div className="flex flex-wrap gap-1.5 opacity-70">
+                <div className="flex flex-wrap gap-1.5 opacity-60">
                   {Object.entries(EXPERIENCE_LEVEL_SECONDARY).map(([label, value]) => (
                     <FilterChip
                       key={value}
@@ -264,7 +265,7 @@ const SearchBuilder = ({ filters, dispatch }) => {
                       value: e.target.value,
                     })
                   }
-                  className="px-2 py-2 text-sm font-dm rounded-input border border-border focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary/20"
+                  className="px-2 py-2.5 text-sm font-dm rounded-lg border border-gray-200 bg-white focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/10"
                   aria-label="Salary currency"
                 >
                   {Object.keys(CURRENCIES).map((c) => (

--- a/src/components/LinkedInSearch/TemplateBar.jsx
+++ b/src/components/LinkedInSearch/TemplateBar.jsx
@@ -23,18 +23,18 @@ const TemplateBar = ({ templates, onApply, onSave, onRemove, hasActiveFilters })
   };
 
   return (
-    <div className="space-y-2">
+    <div className="space-y-2.5">
       <div className="flex items-center justify-between">
-        <span className="text-xs font-dm font-medium text-text-tertiary uppercase tracking-wider">
-          Quick Templates
+        <span className="text-[11px] font-dm font-semibold text-gray-400 uppercase tracking-[0.08em]">
+          Quick Start
         </span>
         {hasActiveFilters && !showSaveInput && (
           <button
             type="button"
             onClick={() => setShowSaveInput(true)}
-            className="inline-flex items-center gap-1 text-xs font-dm text-primary hover:text-primary-hover cursor-pointer"
+            className="inline-flex items-center gap-1 text-[11px] font-dm font-medium text-primary hover:text-primary-hover cursor-pointer uppercase tracking-wider"
           >
-            <Plus size={12} /> Save current
+            <Plus size={11} /> Save current
           </button>
         )}
       </div>
@@ -47,13 +47,13 @@ const TemplateBar = ({ templates, onApply, onSave, onRemove, hasActiveFilters })
             onChange={(e) => setTemplateName(e.target.value)}
             onKeyDown={handleKeyDown}
             placeholder="Template name..."
-            className="flex-1 px-3 py-1.5 text-sm font-dm rounded-button border border-border focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary/20"
+            className="flex-1 px-3 py-1.5 text-sm font-dm rounded-full border border-gray-200 focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary/20 bg-white"
             autoFocus
           />
           <button
             type="button"
             onClick={handleSave}
-            className="p-1.5 rounded-button text-primary hover:bg-primary-light cursor-pointer"
+            className="p-1.5 rounded-full text-primary hover:bg-primary/5 cursor-pointer"
             aria-label="Save template"
           >
             <Check size={16} />
@@ -64,7 +64,7 @@ const TemplateBar = ({ templates, onApply, onSave, onRemove, hasActiveFilters })
               setShowSaveInput(false);
               setTemplateName("");
             }}
-            className="p-1.5 rounded-button text-text-tertiary hover:text-text-primary cursor-pointer"
+            className="p-1.5 rounded-full text-gray-400 hover:text-gray-700 cursor-pointer"
             aria-label="Cancel"
           >
             <X size={16} />
@@ -72,16 +72,16 @@ const TemplateBar = ({ templates, onApply, onSave, onRemove, hasActiveFilters })
         </div>
       )}
 
-      <div className="flex gap-2 overflow-x-auto pb-1 no-scrollbar">
+      <div className="flex gap-1.5 overflow-x-auto pb-1 no-scrollbar">
         {templates.map((template) => (
           <motion.button
             key={template.id}
             type="button"
             whileTap={{ scale: 0.95 }}
             onClick={() => onApply(template)}
-            className="relative group flex-shrink-0 inline-flex items-center gap-1.5 px-3 py-2 rounded-button text-xs font-dm font-medium bg-card border border-border text-text-primary hover:border-primary hover:text-primary transition-colors cursor-pointer focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2"
+            className="relative group flex-shrink-0 inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-[12px] font-dm font-medium bg-gray-50 border border-gray-200 text-gray-600 hover:border-primary/30 hover:text-primary hover:bg-primary/5 transition-all duration-150 cursor-pointer focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2"
           >
-            <Bookmark size={12} />
+            <Bookmark size={11} className="text-gray-400 group-hover:text-primary transition-colors" />
             {template.name}
             {!template.isBuiltIn && onRemove && (
               <span
@@ -97,10 +97,10 @@ const TemplateBar = ({ templates, onApply, onSave, onRemove, hasActiveFilters })
                     onRemove(template.id);
                   }
                 }}
-                className="hidden group-hover:inline-flex ml-1 text-text-tertiary hover:text-red-500"
+                className="hidden group-hover:inline-flex ml-0.5 text-gray-400 hover:text-red-500"
                 aria-label={`Delete ${template.name}`}
               >
-                <X size={12} />
+                <X size={11} />
               </span>
             )}
           </motion.button>

--- a/src/components/LinkedInSearch/URLPreview.jsx
+++ b/src/components/LinkedInSearch/URLPreview.jsx
@@ -12,7 +12,6 @@ const URLPreview = ({ url, isEmpty, onShare }) => {
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
     } catch {
-      // fallback
       const ta = document.createElement("textarea");
       ta.value = url;
       document.body.appendChild(ta);
@@ -39,119 +38,142 @@ const URLPreview = ({ url, isEmpty, onShare }) => {
     }
   }, [onShare]);
 
-  // Color-code URL params
   const renderColoredURL = (rawUrl) => {
     try {
       const urlObj = new URL(rawUrl);
       const base = urlObj.origin + urlObj.pathname;
-      const params = urlObj.searchParams;
-      if (!params.toString()) return <span className="text-text-primary break-all">{rawUrl}</span>;
+      const params = Array.from(urlObj.searchParams.entries());
+      if (!params.length) {
+        return (
+          <div className="flex">
+            <span className="select-none text-gray-600 w-8 text-right mr-3 flex-shrink-0">1</span>
+            <span className="text-gray-400">{rawUrl}</span>
+          </div>
+        );
+      }
 
-      return (
-        <span className="break-all">
-          <span className="text-text-tertiary">{base}?</span>
-          {Array.from(params.entries()).map(([key, value], i) => (
-            <span key={key}>
-              {i > 0 && <span className="text-text-tertiary">&amp;</span>}
-              <span className="text-primary font-semibold">{key}</span>
-              <span className="text-text-tertiary">=</span>
-              <span className="text-text-primary">{decodeURIComponent(value)}</span>
-            </span>
-          ))}
-        </span>
+      const lines = [];
+      lines.push(
+        <div key="base" className="flex">
+          <span className="select-none text-gray-600 w-8 text-right mr-3 flex-shrink-0">1</span>
+          <span className="text-gray-500">{base}?</span>
+        </div>
       );
+
+      params.forEach(([key, value], i) => {
+        lines.push(
+          <div key={key} className="flex">
+            <span className="select-none text-gray-600 w-8 text-right mr-3 flex-shrink-0">{i + 2}</span>
+            <span>
+              {i > 0 && <span className="text-gray-600">&amp;</span>}
+              <span className="text-blue-400 font-semibold">{key}</span>
+              <span className="text-gray-600">=</span>
+              <span className="text-amber-300">{decodeURIComponent(value)}</span>
+            </span>
+          </div>
+        );
+      });
+
+      return <div className="space-y-0.5">{lines}</div>;
     } catch {
-      return <span className="text-text-primary break-all">{rawUrl}</span>;
+      return <span className="text-gray-400 break-all">{rawUrl}</span>;
     }
   };
 
   if (isEmpty) {
     return (
-      <div className="bg-card rounded-card shadow-card p-6 text-center">
-        <Search size={32} className="mx-auto text-text-tertiary mb-3" />
-        <p className="font-dm text-sm text-text-secondary">
-          Start by typing a job title or pick a template above
-        </p>
-      </div>
+      <>
+        <div className="flex flex-col items-center justify-center py-12">
+          <div className="w-12 h-12 rounded-xl bg-white/[0.06] border border-white/10 flex items-center justify-center mb-4">
+            <Search size={20} className="text-gray-500" />
+          </div>
+          <p className="font-dm text-sm text-gray-500 text-center max-w-[200px]">
+            Start by typing a job title or pick a template
+          </p>
+        </div>
+      </>
     );
   }
 
   return (
     <>
       {/* Desktop URL preview */}
-      <div className="hidden md:block bg-card rounded-card shadow-card overflow-hidden">
-        <div className="px-4 py-3 border-b border-border">
-          <span className="text-xs font-dm font-medium text-text-tertiary uppercase tracking-wider">
+      <div className="hidden md:block">
+        <div className="flex items-center justify-between mb-3">
+          <span className="text-[11px] font-dm font-semibold text-gray-500 uppercase tracking-[0.08em]">
             Generated URL
           </span>
+          <span className="text-[11px] font-dm text-gray-600">
+            {Array.from(new URL(url).searchParams).length} params
+          </span>
         </div>
-        <div className="p-4">
-          <motion.div
-            key={url}
-            initial={{ opacity: 0.6 }}
-            animate={{ opacity: 1 }}
-            className="font-mono text-xs leading-relaxed p-3 bg-page rounded-lg border border-border"
+
+        <motion.div
+          key={url}
+          initial={{ opacity: 0.6 }}
+          animate={{ opacity: 1 }}
+          className="font-mono text-[13px] leading-relaxed p-4 bg-black/20 rounded-lg border border-white/10 overflow-x-auto no-scrollbar"
+        >
+          {renderColoredURL(url)}
+        </motion.div>
+
+        <div className="flex flex-wrap items-center gap-2 mt-4">
+          <button
+            type="button"
+            onClick={handleCopy}
+            className="inline-flex items-center gap-1.5 px-4 py-2 rounded-lg text-sm font-dm font-medium bg-blue-500 text-white hover:bg-blue-600 transition-all cursor-pointer focus:outline-none focus:ring-2 focus:ring-blue-400 focus:ring-offset-2 focus:ring-offset-[#1A1A2E]"
           >
-            {renderColoredURL(url)}
-          </motion.div>
-          <div className="flex flex-wrap items-center gap-2 mt-3">
+            <AnimatePresence mode="wait" initial={false}>
+              {copied ? (
+                <motion.span
+                  key="check"
+                  initial={{ scale: 0 }}
+                  animate={{ scale: 1 }}
+                  exit={{ scale: 0 }}
+                  className="inline-flex items-center gap-1.5"
+                >
+                  <Check size={14} /> Copied!
+                </motion.span>
+              ) : (
+                <motion.span
+                  key="copy"
+                  initial={{ scale: 0 }}
+                  animate={{ scale: 1 }}
+                  exit={{ scale: 0 }}
+                  className="inline-flex items-center gap-1.5"
+                >
+                  <Copy size={14} /> Copy URL
+                </motion.span>
+              )}
+            </AnimatePresence>
+          </button>
+          <button
+            type="button"
+            onClick={handleOpen}
+            className="inline-flex items-center gap-1.5 px-4 py-2 rounded-lg text-sm font-dm font-medium border border-white/20 text-white/80 hover:border-white/40 hover:text-white transition-all cursor-pointer focus:outline-none focus:ring-2 focus:ring-white/30 focus:ring-offset-2 focus:ring-offset-[#1A1A2E]"
+          >
+            <ExternalLink size={14} /> Open in LinkedIn
+          </button>
+          {onShare && (
             <button
               type="button"
-              onClick={handleCopy}
-              className="inline-flex items-center gap-1.5 px-3.5 py-2 rounded-button text-sm font-dm font-medium bg-primary text-white hover:bg-primary-hover transition-all cursor-pointer focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2"
+              onClick={handleShare}
+              className="inline-flex items-center gap-1.5 px-4 py-2 rounded-lg text-sm font-dm font-medium border border-white/20 text-white/80 hover:border-white/40 hover:text-white transition-all cursor-pointer focus:outline-none focus:ring-2 focus:ring-white/30 focus:ring-offset-2 focus:ring-offset-[#1A1A2E]"
             >
-              <AnimatePresence mode="wait" initial={false}>
-                {copied ? (
-                  <motion.span
-                    key="check"
-                    initial={{ scale: 0 }}
-                    animate={{ scale: 1 }}
-                    exit={{ scale: 0 }}
-                    className="inline-flex items-center gap-1.5"
-                  >
-                    <Check size={14} /> Copied!
-                  </motion.span>
-                ) : (
-                  <motion.span
-                    key="copy"
-                    initial={{ scale: 0 }}
-                    animate={{ scale: 1 }}
-                    exit={{ scale: 0 }}
-                    className="inline-flex items-center gap-1.5"
-                  >
-                    <Copy size={14} /> Copy URL
-                  </motion.span>
-                )}
-              </AnimatePresence>
+              <Share2 size={14} />
+              {copiedShare ? "Link copied!" : "Share"}
             </button>
-            <button
-              type="button"
-              onClick={handleOpen}
-              className="inline-flex items-center gap-1.5 px-3.5 py-2 rounded-button text-sm font-dm font-medium border border-border text-text-primary hover:border-primary hover:text-primary transition-all cursor-pointer focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2"
-            >
-              <ExternalLink size={14} /> Open in LinkedIn
-            </button>
-            {onShare && (
-              <button
-                type="button"
-                onClick={handleShare}
-                className="inline-flex items-center gap-1.5 px-3.5 py-2 rounded-button text-sm font-dm font-medium border border-border text-text-primary hover:border-primary hover:text-primary transition-all cursor-pointer focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2"
-              >
-                <Share2 size={14} />
-                {copiedShare ? "Link copied!" : "Share"}
-              </button>
-            )}
-          </div>
+          )}
         </div>
       </div>
 
       {/* Mobile sticky bottom bar */}
-      <div className="fixed bottom-0 left-0 right-0 md:hidden bg-card border-t border-border p-3 z-40 shadow-card">
+      <div className="fixed bottom-0 left-0 right-0 md:hidden bg-[#1A1A2E] border-t border-white/10 p-3 z-40">
         <div className="flex gap-2">
           <button
             type="button"
             onClick={handleCopy}
-            className="flex-1 inline-flex items-center justify-center gap-1.5 py-2.5 rounded-button text-sm font-dm font-medium bg-primary text-white cursor-pointer"
+            className="flex-1 inline-flex items-center justify-center gap-1.5 py-2.5 rounded-lg text-sm font-dm font-medium bg-blue-500 text-white cursor-pointer"
           >
             {copied ? (
               <>
@@ -166,7 +188,7 @@ const URLPreview = ({ url, isEmpty, onShare }) => {
           <button
             type="button"
             onClick={handleOpen}
-            className="flex-1 inline-flex items-center justify-center gap-1.5 py-2.5 rounded-button text-sm font-dm font-medium border border-border text-text-primary cursor-pointer"
+            className="flex-1 inline-flex items-center justify-center gap-1.5 py-2.5 rounded-lg text-sm font-dm font-medium border border-white/20 text-white/80 cursor-pointer"
           >
             <ExternalLink size={14} /> Open
           </button>

--- a/src/pages/tools/linkedin-search.js
+++ b/src/pages/tools/linkedin-search.js
@@ -131,7 +131,6 @@ export default function LinkedInSearchPage() {
     );
   }, [activeTab, jobFilters, referralFilters]);
 
-  // Load from URL hash on mount
   useEffect(() => {
     if (typeof window === "undefined") return;
     const hash = window.location.hash.slice(1);
@@ -147,20 +146,16 @@ export default function LinkedInSearchPage() {
     } else {
       jobDispatch({ type: "APPLY_TEMPLATE", filters: { ...INITIAL_JOB_FILTERS, ...decoded.filters } });
     }
-    // Clean hash after loading
     window.history.replaceState(null, "", window.location.pathname);
   }, []);
 
-  // Keyboard shortcuts
   useEffect(() => {
     const handleKeyDown = (e) => {
-      // Cmd/Ctrl + K: focus keywords
       if ((e.metaKey || e.ctrlKey) && e.key === "k") {
         e.preventDefault();
         const ref = SearchBuilder.keywordsRef;
         if (ref?.current) ref.current.focus();
       }
-      // Cmd/Ctrl + Shift + C: copy URL
       if ((e.metaKey || e.ctrlKey) && e.shiftKey && e.key === "C") {
         e.preventDefault();
         if (!isEmpty) navigator.clipboard?.writeText(url);
@@ -213,43 +208,47 @@ export default function LinkedInSearchPage() {
 
       <main
         id="main-content"
-        className="min-h-screen bg-page pt-24 sm:pt-28 pb-16 md:pb-12"
+        className="min-h-screen pb-20 md:pb-12"
+        style={{ background: "radial-gradient(ellipse at 50% 0%, #EEF2FF 0%, #F9FAFB 70%)" }}
       >
         {/* Hero */}
-        <div className="max-w-content mx-auto px-4 lg:px-6">
-          <div className="max-w-[680px] mx-auto text-center mb-8">
+        <div className="max-w-content mx-auto px-4 lg:px-6 pt-24 sm:pt-28">
+          <div className="max-w-[680px] mx-auto text-center mb-10">
             <motion.p
               {...fadeUp}
               transition={{ duration: 0.3 }}
-              className="text-caption uppercase tracking-widest text-primary font-medium mb-4"
+              className="text-[11px] font-dm font-semibold uppercase tracking-[0.1em] text-primary mb-5"
             >
               Smart Search Builder
             </motion.p>
             <motion.h1
               {...fadeUp}
               transition={{ duration: 0.3, delay: 0.05 }}
-              className="text-hero text-text-primary mb-4"
+              className="font-serif-display font-normal text-text-primary mb-5"
+              style={{ fontSize: "clamp(2.25rem, 5vw, 3rem)", lineHeight: 1.1, letterSpacing: "-0.02em" }}
             >
-              LinkedIn Search Builder
+              Build your perfect
+              <br />
+              LinkedIn search.
             </motion.h1>
             <motion.p
               {...fadeUp}
               transition={{ duration: 0.3, delay: 0.15 }}
-              className="text-lg text-gray-500 max-w-[520px] mx-auto mb-3 leading-relaxed"
+              className="text-base font-dm text-gray-500 max-w-[480px] mx-auto mb-4 leading-relaxed"
             >
-              Build the perfect LinkedIn job search URL with smart filters.
+              Craft optimized search URLs with smart filters.
               No sign-in required.
             </motion.p>
             <motion.p
               {...fadeUp}
               transition={{ duration: 0.3, delay: 0.25 }}
-              className="text-xs text-text-tertiary"
+              className="text-xs font-dm text-gray-400"
             >
-              <kbd className="px-1.5 py-0.5 rounded border border-border text-[10px] font-mono">
+              <kbd className="px-1.5 py-0.5 rounded border border-gray-200 bg-white text-[10px] font-mono text-gray-500">
                 {typeof navigator !== "undefined" && /Mac/.test(navigator.userAgent) ? "⌘" : "Ctrl"}+K
               </kbd>{" "}
               to focus search &middot;{" "}
-              <kbd className="px-1.5 py-0.5 rounded border border-border text-[10px] font-mono">
+              <kbd className="px-1.5 py-0.5 rounded border border-gray-200 bg-white text-[10px] font-mono text-gray-500">
                 {typeof navigator !== "undefined" && /Mac/.test(navigator.userAgent) ? "⌘" : "Ctrl"}+⇧+C
               </kbd>{" "}
               to copy URL
@@ -257,34 +256,34 @@ export default function LinkedInSearchPage() {
           </div>
         </div>
 
-        {/* Two-column layout */}
+        {/* Two-column workspace */}
         <motion.div
           {...fadeUp}
           transition={{ duration: 0.3, delay: 0.3 }}
           className="max-w-content mx-auto px-4 lg:px-6"
         >
-          <div className="grid grid-cols-1 lg:grid-cols-[1fr_380px] gap-6">
+          <div className="grid grid-cols-1 lg:grid-cols-[1fr_400px] gap-6">
             {/* Left Column: Filters */}
             <div>
-              {/* Tabs */}
-              <div className="flex bg-card rounded-card shadow-card border border-transparent p-1 mb-4">
+              {/* Tabs — underline style */}
+              <div className="flex gap-0 border-b border-gray-200 mb-5">
                 {tabs.map((tab) => (
                   <button
                     key={tab.id}
                     type="button"
                     onClick={() => setActiveTab(tab.id)}
-                    className={`relative flex-1 flex items-center justify-center gap-2 py-2.5 text-sm font-dm font-medium rounded-button transition-colors cursor-pointer focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 ${
+                    className={`relative flex items-center gap-2 px-4 py-3 text-sm font-dm font-semibold transition-colors cursor-pointer focus:outline-none ${
                       activeTab === tab.id
                         ? "text-primary"
-                        : "text-text-tertiary hover:text-text-primary"
+                        : "text-gray-400 hover:text-gray-700"
                     }`}
                   >
-                    <tab.icon size={16} />
+                    <tab.icon size={15} />
                     {tab.label}
                     {activeTab === tab.id && (
                       <motion.div
-                        layoutId="tab-indicator"
-                        className="absolute inset-0 bg-primary-light rounded-button -z-10"
+                        layoutId="tab-underline"
+                        className="absolute bottom-0 left-0 right-0 h-[2px] bg-primary"
                         transition={{ type: "spring", bounce: 0.15, duration: 0.4 }}
                       />
                     )}
@@ -327,8 +326,16 @@ export default function LinkedInSearchPage() {
               )}
             </div>
 
-            {/* Right Column: Sidebar (sticky) */}
-            <div className="lg:sticky lg:top-20 lg:self-start space-y-4">
+            {/* Right Column: Dark Preview Panel */}
+            <motion.div
+              {...(shouldAnimate
+                ? { initial: { opacity: 0, y: 20, scale: 0.98 }, animate: { opacity: 1, y: 0, scale: 1 } }
+                : { initial: {}, animate: {} }
+              )}
+              transition={{ duration: 0.35, delay: 0.35 }}
+              className="lg:sticky lg:top-20 lg:self-start rounded-2xl p-6 space-y-5"
+              style={{ background: "#1A1A2E" }}
+            >
               {/* Summary */}
               <HumanReadableSummary filters={filters} tab={activeTab} />
 
@@ -336,23 +343,23 @@ export default function LinkedInSearchPage() {
               <URLPreview url={url} isEmpty={isEmpty} onShare={isEmpty ? null : handleShare} />
 
               {/* Cross-link to CareersAt.Tech jobs */}
-              <div className="p-5 bg-card rounded-card shadow-card border border-transparent text-center">
-                <p className="text-sm text-text-secondary mb-2">
-                  Also check CareersAt.Tech for verified listings matching your search
+              <div className="p-4 rounded-lg bg-white/[0.06] border border-white/10 text-center">
+                <p className="text-sm font-dm text-gray-400 mb-2">
+                  Also check CareersAt.Tech for verified listings
                 </p>
                 <Link
                   href="/jobs"
-                  className="inline-flex items-center gap-1.5 text-sm font-dm font-medium text-primary hover:text-primary-hover transition-colors"
+                  className="inline-flex items-center gap-1.5 text-sm font-dm font-medium text-blue-400 hover:text-blue-300 transition-colors"
                 >
-                  Browse jobs on CareersAt.Tech <ArrowRight size={14} />
+                  Browse jobs <ArrowRight size={14} />
                 </Link>
               </div>
 
               {/* Disclaimer */}
-              <p className="text-center text-xs font-dm text-text-tertiary">
-                Not affiliated with LinkedIn Corporation. This tool generates URLs only — no data is collected or sent to any server.
+              <p className="text-center text-[11px] font-dm text-gray-600">
+                Not affiliated with LinkedIn Corporation. This tool generates URLs only — no data is collected.
               </p>
-            </div>
+            </motion.div>
           </div>
         </motion.div>
       </main>


### PR DESCRIPTION
## Summary

Complete UI overhaul of `/tools/linkedin-search` with a "Code Studio" aesthetic:

- **Dark preview panel** (`#1A1A2E`) with line-numbered, syntax-highlighted URL display
- **Instrument Serif** hero headline, DM Sans for all UI text
- **Radial gradient** hero background
- **Underline tab switcher** replacing filled-background tabs
- **Single-card filter workspace** with open sections and dividers
- **Refined filter chips** with inner shadow on selected state
- **Orchestrated page-load animation** with staggered reveals
- **Dark mobile sticky bar** matching the preview panel

## Test plan

- [ ] Visit `/tools/linkedin-search` and verify layout renders
- [ ] Type keywords and select chips — URL updates in dark panel
- [ ] Switch between Job Search and Referral Finder tabs
- [ ] Apply a Quick Start template
- [ ] Copy URL and Open in LinkedIn buttons work
- [ ] Mobile viewport — dark sticky bottom bar
- [ ] `prefers-reduced-motion` disables animations

https://claude.ai/code/session_01PLHT612vQ3atkM4BXFzYBX