### PR TITLE
Redesign LinkedIn Search with "Press & Proof" letterpress UI

### DIFF
--- a/DESIGN_SYSTEM.md
+++ b/DESIGN_SYSTEM.md
@@ -634,33 +634,115 @@ Every page on CareersAt.Tech follows one of these structural templates:
 [Footer]
 ```
 
-### 17.4 Tool Page (`/tools/linkedin-search`)
+### 17.4 Tool Page (`/tools/linkedin-search`) — "Press & Proof" sub-system
+
+This page is the **first named sub-system** in the design system. It overrides the standard palette, typography, and shadow set for `/tools/linkedin-search` only. All other tool pages continue to follow the main system (sections 2–16).
+
+**Aesthetic:** Typesetter's workbench. A URL builder whose output is typography — so the page renders like a letterpress proof pulled off a warm paper stock.
+
+#### 17.4.1 Page structure
 
 ```
 [Navbar]
-[Hero — eyebrow + headline + description + keyboard shortcuts]
-[Two-column: Filter builder (left) + Sticky sidebar (right)]
+[Atmosphere — torn-paper top edge + dot-grid + ellipse glow at top center]
+[Hero — stamp mark + issue number + serif display headline with italic accents + letterpress kbd shortcuts]
+[Two-column: Composing stick (left) + Proof press (right)]
   Left column:
-    [Tab switcher — bg-card, rounded-card, shadow-card, p-1]
-    [Template bar — horizontal scroll, rounded-button pills]
-    [Active filters bar — removable chips, horizontal scroll]
-    [Filter sections — standard cards (bg-card, rounded-card, shadow-card)]
+    [Tab switcher — numeral prefixes (01·02), terracotta underline via Framer layoutId]
+    [Standing-type bar — template plates, horizontal scroll]
+    [Set bar — active filter chips in mono-proof]
+    [Composing stick — letterpress card, dashed rule dividers between sections]
   Right column (sticky):
-    [Human-readable summary — standard card]
-    [URL preview — standard card with color-coded URL]
-    [Cross-link CTA — standard card]
-    [Disclaimer text]
-[Mobile: Sticky bottom bar with copy + open buttons]
+    [Proof press — deep ink panel with masthead + plate number]
+    [Reading proof — Instrument Serif italic summary with terracotta underlines]
+    [Proof — mono-proof URL with line numbers, colored params, ink-in highlight on change]
+    [Colophon CTA — cross-link to /jobs]
+    [Imprint disclaimer]
+[Mobile: Sticky bottom bar with Pull proof + Open buttons]
 [Footer]
 ```
 
-**Tool page rules:**
-- Hero uses standard fadeUp animation pattern (motion.p, motion.h1 with staggered delays)
-- All cards use standard `bg-card rounded-card shadow-card` — no custom borders or accents
-- Filter chips follow design system section 10.2 pattern
-- Buttons follow section 7 variants (primary for main CTA, ghost for secondary)
-- All interactive elements have `focus:ring-2 focus:ring-primary focus:ring-offset-2`
-- Uses standard site colors — no page-specific color palettes
+#### 17.4.2 Palette override
+
+| Token                        | Hex       | Tailwind Class              | Usage                                  |
+|------------------------------|-----------|-----------------------------|-----------------------------------------|
+| `linkedin.bg`                | `#F4EEE4` | `bg-linkedin-bg`            | Page background (warm cream paper)      |
+| `linkedin.surface`           | `#FCF8F1` | `bg-linkedin-surface`       | Card surfaces                           |
+| `linkedin.ink`               | `#1A1614` | `text-linkedin-ink`         | Primary text (warm near-black)          |
+| `linkedin.ink-soft`          | `#3D332E` | `text-linkedin-ink-soft`    | Secondary text                          |
+| `linkedin.accent`            | `#C75B3F` | `*-linkedin-accent`         | Terracotta — dominant accent            |
+| `linkedin.accent-hover`      | `#B5492F` | `*-linkedin-accent-hover`   | Accent hover                            |
+| `linkedin.accent-light`      | `#FFF5F2` | `bg-linkedin-accent-light`  | Selected-chip background                |
+| `linkedin.rule`              | `#D9CFBF` | `border-linkedin-rule`      | Hairline + dashed dividers              |
+| `linkedin.muted`             | `#8A8580` | `text-linkedin-muted`       | Captions, tertiary text                 |
+| `linkedin.highlight`         | `#C99B3C` | `*-linkedin-highlight`      | Aged gold — param values, stamps        |
+| `linkedin.proof-bg`          | `#1A1614` | `bg-linkedin-proof-bg`      | Dark proof panel                        |
+| `linkedin.proof-surface`     | `#2A2320` | `bg-linkedin-proof-surface` | Raised surface inside proof panel       |
+| `linkedin.proof-rule`        | `#3D332E` | `border-linkedin-proof-rule`| Dividers inside proof panel             |
+
+Primary blue (`#2563EB`) is **not used** on this page.
+
+#### 17.4.3 Typography override
+
+| Role                          | Font (Tailwind)               | Notes                                    |
+|-------------------------------|-------------------------------|-------------------------------------------|
+| Display headline              | `font-serif-display`          | Instrument Serif, italic on accent words  |
+| UI body, chips, inputs        | `font-sans-linkedin`          | Bricolage Grotesque                       |
+| URL preview, kbd, section labels, stamps | `font-mono-proof`  | JetBrains Mono, uppercase, wide tracking  |
+
+Inter and DM Sans are **not used** in this page's content area.
+
+#### 17.4.4 Shadow & radius
+
+- `shadow-letterpress` — standard card elevation (`0 1px 0 rgba(26,22,20,0.04), 0 8px 20px -12px rgba(26,22,20,0.12)`)
+- `shadow-letterpress-hover` — hover state for cards
+- `shadow-letterpress-inset` — keycaps and inked stamp marks
+- `shadow-proof-panel` — the dark sticky proof panel
+- Cards use `rounded-[14px]`; chips remain `rounded-full`; inputs use `rounded-[8px]`
+
+#### 17.4.5 Atmosphere
+
+- Page base: `bg-linkedin-bg`
+- Dot-grid + faint horizontal rule: `radial-gradient(rgba(61,51,46,0.14) 1px, transparent 1px)` at `24px 24px` layered with a `1px` horizontal rule gradient at `100% 40px`
+- Top torn-paper edge: inline `<svg>` with a jagged path, `aria-hidden`
+- Warm vignette: radial gradient `rgba(201,155,60,0.18) → rgba(199,91,63,0.05) → transparent` at top center
+- All decorative overlays use `pointer-events: none` and `aria-hidden="true"`
+
+#### 17.4.6 Motion
+
+- Entrance: staggered `press-reveal` (y:6 → 0, 360ms) on eyebrow → headline → description → shortcuts → workspace
+- Tab underline: keep Framer Motion `layoutId="tab-underline"` with terracotta fill
+- Chip selection: stamp bloom — pseudo dot scales 0.8 → 1.04 → 1 over 220ms
+- URL param updates: `animate-ink-in` keyframe (gold → transparent, 520ms) re-triggered via `key={paramValue}` on each param span
+- All honor `prefers-reduced-motion`; no animation exceeds 540ms
+
+#### 17.4.7 Voice overlay (UI copy)
+
+The page adopts a light typographic vocabulary for microcopy only (not for content):
+- "Composing stick" — filter panel
+- "Proof press" / "Proof" — URL preview area
+- "Reading proof" — human-readable summary
+- "Standing type" / "plates" — templates
+- "Set / Clear all" — active filters bar
+- "Pull a proof" — copy button
+- "Stamped!" — copied confirmation
+- "Colophon" — how-it-works section
+- "Imprint" — disclaimer
+
+This vocabulary is **scoped to this page only**. Do not introduce these terms elsewhere.
+
+#### 17.4.8 Rules for this page
+
+- Do not mix in standard `primary-blue` tokens on this page — use `linkedin-accent` for all interactive highlights
+- Dashed dividers (`border-dashed border-linkedin-rule`) separate filter sections; solid `border-linkedin-rule` separates cards from context
+- Keyboard shortcut kbd caps: `bg-linkedin-surface border border-linkedin-rule shadow-letterpress-inset`
+- Focus rings: `focus-visible:ring-2 focus-visible:ring-linkedin-accent focus-visible:ring-offset-2` (offset matches surrounding surface)
+- Minimum hit targets remain 44×44px (accessibility rule, section 13, still applies)
+- All other global rules (WCAG AA contrast, `prefers-reduced-motion`, next/image, semantic HTML) still apply
+
+#### 17.4.9 When to extend this sub-system
+
+Do **not** apply Press & Proof styling to other tool pages without an explicit decision recorded in this file. If a second tool earns its own named sub-system, add it here as §17.5, not by widening §17.4.
 
 ---
 
@@ -760,7 +842,7 @@ const config = {
 - Use shadows heavier than `shadow-lg`
 - Use font weight 300, 800, or 900
 - Use more than 2 trust badges on a single card
-- Introduce new colors without adding them to this file
+- Introduce new colors without adding them to this file (exception: a page may adopt a named sub-system in §17 with its own palette, typography, and shadow set — e.g. §17.4 Press & Proof for `/tools/linkedin-search`)
 - Place the WhatsApp CTA more than once per page
 - Use sidebar filters — horizontal chips only
 - Use banner/hero images — text-driven heroes only
@@ -783,5 +865,6 @@ When updating this file:
 
 | Date       | Change                                     |
 |------------|---------------------------------------------|
+| Apr 2026   | §17.4 rewritten as "Press & Proof" sub-system for `/tools/linkedin-search` (warm cream + terracotta palette, Bricolage Grotesque + JetBrains Mono + Instrument Serif, letterpress shadows, ink-in keyframe). §19 Don't amended to allow named sub-systems. |
 | Apr 2026   | Added Tool Page template (17.4) for LinkedIn Search Builder |
 | Apr 2026   | Initial design system created               |

--- a/src/components/LinkedInSearch/ActiveFiltersBar.jsx
+++ b/src/components/LinkedInSearch/ActiveFiltersBar.jsx
@@ -85,25 +85,25 @@ const ActiveFiltersBar = ({ filters, tab, onRemoveFilter, onClearAll }) => {
 
   return (
     <div className="flex items-center gap-2 overflow-x-auto pb-1 no-scrollbar">
-      <span className="text-[11px] font-dm font-medium text-gray-400 uppercase tracking-wider whitespace-nowrap flex-shrink-0">
-        Active
+      <span className="font-mono-proof text-[10.5px] uppercase tracking-[0.22em] text-linkedin-accent whitespace-nowrap flex-shrink-0">
+        Set
       </span>
       <AnimatePresence mode="popLayout">
         {chips.map((chip) => (
           <motion.span
             key={`${chip.key}-${chip.value}`}
             layout
-            initial={{ opacity: 0, scale: 0.8 }}
+            initial={{ opacity: 0, scale: 0.85 }}
             animate={{ opacity: 1, scale: 1 }}
-            exit={{ opacity: 0, scale: 0.8 }}
-            transition={{ duration: 0.15 }}
-            className="inline-flex items-center gap-1 px-2.5 py-1 rounded-full text-xs font-dm font-medium bg-primary/10 text-primary whitespace-nowrap flex-shrink-0"
+            exit={{ opacity: 0, scale: 0.85 }}
+            transition={{ duration: 0.18 }}
+            className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full font-mono-proof text-[11.5px] font-medium bg-linkedin-accent-light text-linkedin-accent border border-linkedin-accent/30 whitespace-nowrap flex-shrink-0"
           >
             {chip.label}
             <button
               type="button"
               onClick={() => onRemoveFilter(chip.key, chip.value)}
-              className="ml-0.5 hover:text-primary-hover cursor-pointer"
+              className="ml-0.5 hover:text-linkedin-accent-hover cursor-pointer"
               aria-label={`Remove ${chip.label} filter`}
             >
               <X size={12} />
@@ -114,7 +114,7 @@ const ActiveFiltersBar = ({ filters, tab, onRemoveFilter, onClearAll }) => {
       <button
         type="button"
         onClick={onClearAll}
-        className="text-[11px] font-dm font-medium text-gray-400 hover:text-primary whitespace-nowrap flex-shrink-0 cursor-pointer uppercase tracking-wider"
+        className="font-mono-proof text-[10.5px] font-semibold uppercase tracking-[0.2em] text-linkedin-muted hover:text-linkedin-accent whitespace-nowrap flex-shrink-0 cursor-pointer"
       >
         Clear all
       </button>

--- a/src/components/LinkedInSearch/FilterChip.jsx
+++ b/src/components/LinkedInSearch/FilterChip.jsx
@@ -3,27 +3,34 @@ import { motion } from "framer-motion";
 const FilterChip = ({ label, selected, onClick, size = "md" }) => {
   const sizeClasses =
     size === "sm"
-      ? "px-3 py-1 text-xs min-h-[32px]"
-      : "px-3.5 py-1.5 text-sm min-h-[36px] md:min-h-[32px]";
+      ? "px-3 py-1 text-[12px] min-h-[32px]"
+      : "px-3.5 py-1.5 text-[13px] min-h-[36px] md:min-h-[32px]";
 
   return (
     <motion.button
       type="button"
       onClick={onClick}
-      whileTap={{ scale: 0.95 }}
+      whileTap={{ scale: 0.96 }}
       className={`
-        inline-flex items-center rounded-full font-dm font-medium transition-all duration-150 cursor-pointer select-none
-        focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2
+        relative inline-flex items-center gap-1.5 rounded-full font-sans-linkedin font-medium cursor-pointer select-none
+        transition-[background,color,border-color,transform,box-shadow] duration-150
+        focus:outline-none focus-visible:ring-2 focus-visible:ring-linkedin-accent focus-visible:ring-offset-2 focus-visible:ring-offset-linkedin-bg
         ${sizeClasses}
         ${
           selected
-            ? "bg-primary text-white shadow-[inset_0_1px_0_rgba(255,255,255,0.15)] border border-primary hover:bg-primary-hover"
-            : "bg-white border border-gray-200 text-gray-700 hover:border-primary/40 hover:text-primary"
+            ? "bg-linkedin-accent-light text-linkedin-accent border border-linkedin-accent shadow-[inset_0_-1px_0_rgba(181,73,47,0.25)] hover:bg-[#FFEEE7]"
+            : "bg-linkedin-surface border border-linkedin-rule text-linkedin-ink-soft hover:border-linkedin-accent/60 hover:text-linkedin-accent hover:-translate-y-[1px]"
         }
       `}
       aria-pressed={selected}
     >
-      {label}
+      {selected && (
+        <span
+          aria-hidden="true"
+          className="inline-block h-1.5 w-1.5 rounded-full bg-linkedin-accent animate-stamp-bloom"
+        />
+      )}
+      <span className="leading-none">{label}</span>
     </motion.button>
   );
 };

--- a/src/components/LinkedInSearch/FilterSection.jsx
+++ b/src/components/LinkedInSearch/FilterSection.jsx
@@ -12,24 +12,28 @@ const FilterSection = ({
   const [open, setOpen] = useState(tier === 1 ? defaultOpen : false);
 
   return (
-    <div className="py-4 first:pt-0 last:pb-0 border-b border-gray-100 last:border-b-0">
+    <div className="py-4 first:pt-0 last:pb-0 border-b border-dashed border-linkedin-rule last:border-b-0">
       <button
         type="button"
         onClick={() => setOpen(!open)}
-        className="w-full flex items-center justify-between text-left cursor-pointer group focus:outline-none"
+        className="w-full flex items-center justify-between text-left cursor-pointer group focus:outline-none focus-visible:ring-2 focus-visible:ring-linkedin-accent focus-visible:ring-offset-2 focus-visible:ring-offset-linkedin-surface rounded-[4px]"
         aria-expanded={open}
       >
-        <div className="flex items-center gap-2">
-          {Icon && <Icon size={15} className="text-gray-400 group-hover:text-primary transition-colors" />}
-          <span className="font-dm font-semibold text-[13px] uppercase tracking-wider text-gray-500 group-hover:text-gray-700 transition-colors">
+        <div className="flex items-center gap-2.5">
+          {Icon && (
+            <span className="inline-flex h-6 w-6 items-center justify-center rounded-[4px] bg-linkedin-accent-light text-linkedin-accent transition-colors group-hover:bg-linkedin-accent group-hover:text-linkedin-surface">
+              <Icon size={13} strokeWidth={2.25} />
+            </span>
+          )}
+          <span className="font-mono-proof text-[10.5px] uppercase tracking-[0.18em] text-linkedin-ink-soft group-hover:text-linkedin-ink transition-colors">
             {title}
           </span>
         </div>
         <motion.div
           animate={{ rotate: open ? 180 : 0 }}
-          transition={{ duration: 0.2 }}
+          transition={{ duration: 0.22 }}
         >
-          <ChevronDown size={14} className="text-gray-400" />
+          <ChevronDown size={14} className="text-linkedin-muted" />
         </motion.div>
       </button>
 
@@ -39,7 +43,7 @@ const FilterSection = ({
             initial={{ height: 0, opacity: 0 }}
             animate={{ height: "auto", opacity: 1 }}
             exit={{ height: 0, opacity: 0 }}
-            transition={{ duration: 0.2, ease: "easeInOut" }}
+            transition={{ duration: 0.22, ease: "easeInOut" }}
             className="overflow-hidden"
           >
             <div className="pt-3">{children}</div>

--- a/src/components/LinkedInSearch/HumanReadableSummary.jsx
+++ b/src/components/LinkedInSearch/HumanReadableSummary.jsx
@@ -9,17 +9,26 @@ const HumanReadableSummary = ({ filters, tab }) => {
   const rendered = parts.map((part, i) => {
     if (part.startsWith("**") && part.endsWith("**")) {
       return (
-        <strong key={i} className="text-white font-semibold">
+        <em
+          key={i}
+          className="not-italic font-serif-display italic text-linkedin-bg font-normal border-b border-linkedin-accent/70 px-0.5"
+        >
           {part.slice(2, -2)}
-        </strong>
+        </em>
       );
     }
     return <span key={i}>{part}</span>;
   });
 
   return (
-    <div className="px-4 py-3 rounded-lg bg-white/[0.06] border border-white/10">
-      <p className="font-dm text-sm text-gray-300 leading-relaxed italic">
+    <div className="relative px-4 py-3.5 rounded-[10px] bg-linkedin-proof-surface border border-linkedin-proof-rule">
+      <span
+        aria-hidden="true"
+        className="absolute -top-2 left-4 px-1.5 font-mono-proof text-[9.5px] uppercase tracking-[0.22em] text-linkedin-highlight bg-linkedin-proof-bg"
+      >
+        Reading proof
+      </span>
+      <p className="font-sans-linkedin text-[13.5px] text-linkedin-rule/90 leading-[1.6]">
         {rendered}
       </p>
     </div>

--- a/src/components/LinkedInSearch/ReferralFinder.jsx
+++ b/src/components/LinkedInSearch/ReferralFinder.jsx
@@ -13,14 +13,28 @@ import FilterChip from "./FilterChip";
 import { CONNECTION_DEGREE } from "./lib/linkedin-params";
 
 const inputClasses =
-  "w-full px-3 py-2.5 text-sm font-dm rounded-lg border border-gray-200 bg-white focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/10 placeholder:text-gray-400 transition-all";
+  "w-full px-3.5 py-2.5 text-[14px] font-sans-linkedin text-linkedin-ink rounded-[8px] border border-linkedin-rule bg-linkedin-surface focus:border-linkedin-accent focus:outline-none focus:ring-2 focus:ring-linkedin-accent/25 placeholder:text-linkedin-muted transition-colors";
 
 const ReferralFinder = ({ filters, dispatch }) => {
   const [showHowItWorks, setShowHowItWorks] = useState(false);
 
   return (
-    <div className="space-y-0">
-      <div className="bg-white rounded-xl shadow-card p-5">
+    <div className="space-y-3">
+      <div className="bg-linkedin-surface rounded-[14px] shadow-letterpress border border-linkedin-rule p-5 sm:p-6">
+        <div className="flex items-baseline justify-between mb-4 pb-3 border-b border-linkedin-rule">
+          <div className="flex items-baseline gap-2">
+            <span className="font-mono-proof text-[10px] uppercase tracking-[0.22em] text-linkedin-accent">
+              §
+            </span>
+            <span className="font-serif-display italic text-[18px] leading-none text-linkedin-ink">
+              Composing stick
+            </span>
+          </div>
+          <span className="font-mono-proof text-[10px] uppercase tracking-[0.2em] text-linkedin-muted">
+            Referral Finder
+          </span>
+        </div>
+
         <FilterSection title="Company" icon={Building2} defaultOpen={true}>
           <input
             type="text"
@@ -77,24 +91,26 @@ const ReferralFinder = ({ filters, dispatch }) => {
       </div>
 
       {/* How Referral Finder Works */}
-      <div className="mt-3 bg-white rounded-xl shadow-card overflow-hidden">
+      <div className="bg-linkedin-surface rounded-[14px] shadow-letterpress border border-linkedin-rule overflow-hidden">
         <button
           type="button"
           onClick={() => setShowHowItWorks(!showHowItWorks)}
           className="w-full flex items-center justify-between px-5 py-3.5 text-left cursor-pointer focus:outline-none group"
           aria-expanded={showHowItWorks}
         >
-          <div className="flex items-center gap-2">
-            <Info size={15} className="text-primary" />
-            <span className="font-dm font-semibold text-[13px] uppercase tracking-wider text-gray-500 group-hover:text-gray-700 transition-colors">
-              How it works
+          <div className="flex items-center gap-2.5">
+            <span className="inline-flex h-6 w-6 items-center justify-center rounded-[4px] bg-linkedin-accent-light text-linkedin-accent">
+              <Info size={13} strokeWidth={2.25} />
+            </span>
+            <span className="font-mono-proof text-[10.5px] uppercase tracking-[0.18em] text-linkedin-ink-soft group-hover:text-linkedin-ink transition-colors">
+              Colophon · how it works
             </span>
           </div>
           <motion.div
             animate={{ rotate: showHowItWorks ? 180 : 0 }}
-            transition={{ duration: 0.2 }}
+            transition={{ duration: 0.22 }}
           >
-            <ChevronDown size={14} className="text-gray-400" />
+            <ChevronDown size={14} className="text-linkedin-muted" />
           </motion.div>
         </button>
 
@@ -104,23 +120,23 @@ const ReferralFinder = ({ filters, dispatch }) => {
               initial={{ height: 0, opacity: 0 }}
               animate={{ height: "auto", opacity: 1 }}
               exit={{ height: 0, opacity: 0 }}
-              transition={{ duration: 0.2 }}
+              transition={{ duration: 0.22 }}
               className="overflow-hidden"
             >
-              <div className="px-5 pb-4 space-y-2">
-                <p className="text-sm font-dm text-gray-600 leading-relaxed">
-                  The Referral Finder builds a LinkedIn people search URL to help you find
-                  employees at a specific company who could potentially refer you.
+              <div className="px-5 pb-4 space-y-2.5 border-t border-dashed border-linkedin-rule pt-3">
+                <p className="font-sans-linkedin text-[14px] text-linkedin-ink-soft leading-relaxed">
+                  The Referral Finder sets type for a LinkedIn people-search URL so
+                  you can find employees at a specific company who might refer you.
                 </p>
-                <ol className="list-decimal list-inside text-sm font-dm text-gray-600 space-y-1.5 leading-relaxed">
+                <ol className="list-decimal list-inside font-sans-linkedin text-[14px] text-linkedin-ink-soft space-y-1.5 leading-relaxed marker:text-linkedin-accent marker:font-mono-proof">
                   <li>Enter the company name and the role you want a referral for</li>
                   <li>Select connection degree (1st degree connections are best for referrals)</li>
                   <li>Open the generated URL in LinkedIn</li>
-                  <li>Reach out to people with a personalized message mentioning the role</li>
+                  <li>Reach out with a personalized message mentioning the role</li>
                 </ol>
-                <p className="text-xs font-dm text-gray-400 mt-2">
-                  Tip: Filter by 1st connections first — they are most likely to help.
-                  If none are found, try 2nd connections and ask mutual contacts for an introduction.
+                <p className="font-mono-proof text-[11px] text-linkedin-muted mt-3 pt-2 border-t border-dashed border-linkedin-rule">
+                  Tip · filter by 1st connections first. If none found, try 2nd
+                  connections and ask mutual contacts for an introduction.
                 </p>
               </div>
             </motion.div>

--- a/src/components/LinkedInSearch/SearchBuilder.jsx
+++ b/src/components/LinkedInSearch/SearchBuilder.jsx
@@ -26,7 +26,7 @@ import {
 } from "./lib/linkedin-params";
 
 const inputClasses =
-  "w-full px-3 py-2.5 text-sm font-dm rounded-lg border border-gray-200 bg-white focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/10 placeholder:text-gray-400 transition-all";
+  "w-full px-3.5 py-2.5 text-[14px] font-sans-linkedin text-linkedin-ink rounded-[8px] border border-linkedin-rule bg-linkedin-surface focus:border-linkedin-accent focus:outline-none focus:ring-2 focus:ring-linkedin-accent/25 placeholder:text-linkedin-muted transition-colors";
 
 const SearchBuilder = ({ filters, dispatch }) => {
   const [showMoreFilters, setShowMoreFilters] = useState(false);
@@ -49,8 +49,31 @@ const SearchBuilder = ({ filters, dispatch }) => {
     filters.easyApply ||
     filters.minSalary;
 
+  const moreCount = [
+    filters.workMode.length,
+    filters.experienceLevel.length,
+    filters.sortBy ? 1 : 0,
+    filters.easyApply ? 1 : 0,
+    filters.minSalary ? 1 : 0,
+  ].reduce((a, b) => a + b, 0);
+
   return (
-    <div className="bg-white rounded-xl shadow-card p-5">
+    <div className="relative bg-linkedin-surface rounded-[14px] shadow-letterpress border border-linkedin-rule p-5 sm:p-6">
+      {/* Composing-stick header */}
+      <div className="flex items-baseline justify-between mb-4 pb-3 border-b border-linkedin-rule">
+        <div className="flex items-baseline gap-2">
+          <span className="font-mono-proof text-[10px] uppercase tracking-[0.22em] text-linkedin-accent">
+            §
+          </span>
+          <span className="font-serif-display italic text-[18px] leading-none text-linkedin-ink">
+            Composing stick
+          </span>
+        </div>
+        <span className="font-mono-proof text-[10px] uppercase tracking-[0.2em] text-linkedin-muted">
+          Job Search
+        </span>
+      </div>
+
       {/* Tier 1: Always visible */}
       <FilterSection title="Keywords" icon={Search} defaultOpen={true}>
         <input
@@ -67,7 +90,7 @@ const SearchBuilder = ({ filters, dispatch }) => {
       </FilterSection>
 
       <FilterSection title="Location" icon={MapPin} defaultOpen={true}>
-        <div className="space-y-2">
+        <div className="space-y-2.5">
           <div className="flex flex-wrap gap-1.5">
             {INDIAN_LOCATIONS.map((loc) => (
               <FilterChip
@@ -134,23 +157,17 @@ const SearchBuilder = ({ filters, dispatch }) => {
       </FilterSection>
 
       {/* Tier 2: More Filters toggle */}
-      <div className="pt-4 border-t border-gray-100 mt-4">
+      <div className="pt-4 border-t border-linkedin-rule mt-4">
         <button
           type="button"
           onClick={() => setShowMoreFilters(!showMoreFilters)}
-          className="w-full flex items-center justify-center gap-2 py-2 text-[13px] font-dm font-semibold text-primary hover:text-primary-hover transition-colors cursor-pointer rounded-lg focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 uppercase tracking-wider"
+          className="w-full flex items-center justify-center gap-2 py-2.5 font-mono-proof text-[11px] font-semibold uppercase tracking-[0.2em] text-linkedin-accent hover:text-linkedin-accent-hover transition-colors cursor-pointer rounded-[6px] focus:outline-none focus-visible:ring-2 focus-visible:ring-linkedin-accent focus-visible:ring-offset-2 focus-visible:ring-offset-linkedin-surface"
         >
           <SlidersHorizontal size={13} />
-          {showMoreFilters ? "Less filters" : "More filters"}
+          {showMoreFilters ? "Fewer marks" : "Set additional marks"}
           {hasMoreFilters && !showMoreFilters && (
-            <span className="inline-flex items-center justify-center w-5 h-5 rounded-full bg-primary text-white text-[10px] font-bold">
-              {[
-                filters.workMode.length,
-                filters.experienceLevel.length,
-                filters.sortBy ? 1 : 0,
-                filters.easyApply ? 1 : 0,
-                filters.minSalary ? 1 : 0,
-              ].reduce((a, b) => a + b, 0)}
+            <span className="inline-flex items-center justify-center w-5 h-5 rounded-full bg-linkedin-highlight text-linkedin-ink text-[10px] font-bold">
+              {moreCount}
             </span>
           )}
         </button>
@@ -162,7 +179,7 @@ const SearchBuilder = ({ filters, dispatch }) => {
             initial={{ height: 0, opacity: 0 }}
             animate={{ height: "auto", opacity: 1 }}
             exit={{ height: 0, opacity: 0 }}
-            transition={{ duration: 0.25 }}
+            transition={{ duration: 0.28 }}
             className="overflow-hidden"
           >
             <FilterSection title="Work Mode" icon={Building2} tier={2} defaultOpen={true}>
@@ -265,7 +282,7 @@ const SearchBuilder = ({ filters, dispatch }) => {
                       value: e.target.value,
                     })
                   }
-                  className="px-2 py-2.5 text-sm font-dm rounded-lg border border-gray-200 bg-white focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/10"
+                  className="px-2.5 py-2.5 text-[14px] font-mono-proof rounded-[8px] border border-linkedin-rule bg-linkedin-surface text-linkedin-ink focus:border-linkedin-accent focus:outline-none focus:ring-2 focus:ring-linkedin-accent/25"
                   aria-label="Salary currency"
                 >
                   {Object.keys(CURRENCIES).map((c) => (

--- a/src/components/LinkedInSearch/TemplateBar.jsx
+++ b/src/components/LinkedInSearch/TemplateBar.jsx
@@ -25,16 +25,21 @@ const TemplateBar = ({ templates, onApply, onSave, onRemove, hasActiveFilters })
   return (
     <div className="space-y-2.5">
       <div className="flex items-center justify-between">
-        <span className="text-[11px] font-dm font-semibold text-gray-400 uppercase tracking-[0.08em]">
-          Quick Start
-        </span>
+        <div className="flex items-baseline gap-2">
+          <span className="font-mono-proof text-[10px] uppercase tracking-[0.22em] text-linkedin-accent">
+            ¶
+          </span>
+          <span className="font-mono-proof text-[10.5px] uppercase tracking-[0.22em] text-linkedin-ink-soft">
+            Standing type · quick plates
+          </span>
+        </div>
         {hasActiveFilters && !showSaveInput && (
           <button
             type="button"
             onClick={() => setShowSaveInput(true)}
-            className="inline-flex items-center gap-1 text-[11px] font-dm font-medium text-primary hover:text-primary-hover cursor-pointer uppercase tracking-wider"
+            className="inline-flex items-center gap-1 font-mono-proof text-[10.5px] font-semibold uppercase tracking-[0.18em] text-linkedin-accent hover:text-linkedin-accent-hover cursor-pointer"
           >
-            <Plus size={11} /> Save current
+            <Plus size={11} /> Save plate
           </button>
         )}
       </div>
@@ -46,14 +51,14 @@ const TemplateBar = ({ templates, onApply, onSave, onRemove, hasActiveFilters })
             value={templateName}
             onChange={(e) => setTemplateName(e.target.value)}
             onKeyDown={handleKeyDown}
-            placeholder="Template name..."
-            className="flex-1 px-3 py-1.5 text-sm font-dm rounded-full border border-gray-200 focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary/20 bg-white"
+            placeholder="Name this plate…"
+            className="flex-1 px-3 py-1.5 text-[13.5px] font-sans-linkedin text-linkedin-ink rounded-full border border-linkedin-rule bg-linkedin-surface focus:border-linkedin-accent focus:outline-none focus:ring-2 focus:ring-linkedin-accent/20"
             autoFocus
           />
           <button
             type="button"
             onClick={handleSave}
-            className="p-1.5 rounded-full text-primary hover:bg-primary/5 cursor-pointer"
+            className="p-1.5 rounded-full text-linkedin-accent hover:bg-linkedin-accent-light cursor-pointer"
             aria-label="Save template"
           >
             <Check size={16} />
@@ -64,7 +69,7 @@ const TemplateBar = ({ templates, onApply, onSave, onRemove, hasActiveFilters })
               setShowSaveInput(false);
               setTemplateName("");
             }}
-            className="p-1.5 rounded-full text-gray-400 hover:text-gray-700 cursor-pointer"
+            className="p-1.5 rounded-full text-linkedin-muted hover:text-linkedin-ink cursor-pointer"
             aria-label="Cancel"
           >
             <X size={16} />
@@ -72,16 +77,19 @@ const TemplateBar = ({ templates, onApply, onSave, onRemove, hasActiveFilters })
         </div>
       )}
 
-      <div className="flex gap-1.5 overflow-x-auto pb-1 no-scrollbar">
+      <div className="flex gap-2 overflow-x-auto pb-1 no-scrollbar">
         {templates.map((template) => (
           <motion.button
             key={template.id}
             type="button"
-            whileTap={{ scale: 0.95 }}
+            whileTap={{ scale: 0.96 }}
             onClick={() => onApply(template)}
-            className="relative group flex-shrink-0 inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-[12px] font-dm font-medium bg-gray-50 border border-gray-200 text-gray-600 hover:border-primary/30 hover:text-primary hover:bg-primary/5 transition-all duration-150 cursor-pointer focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2"
+            className="relative group flex-shrink-0 inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full font-sans-linkedin text-[12.5px] font-medium bg-linkedin-surface border border-linkedin-rule text-linkedin-ink-soft hover:border-linkedin-accent hover:text-linkedin-accent hover:-translate-y-[1px] transition-all duration-150 cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-linkedin-accent focus-visible:ring-offset-2 focus-visible:ring-offset-linkedin-bg"
           >
-            <Bookmark size={11} className="text-gray-400 group-hover:text-primary transition-colors" />
+            <Bookmark
+              size={11}
+              className="text-linkedin-muted group-hover:text-linkedin-accent transition-colors"
+            />
             {template.name}
             {!template.isBuiltIn && onRemove && (
               <span
@@ -97,7 +105,7 @@ const TemplateBar = ({ templates, onApply, onSave, onRemove, hasActiveFilters })
                     onRemove(template.id);
                   }
                 }}
-                className="hidden group-hover:inline-flex ml-0.5 text-gray-400 hover:text-red-500"
+                className="hidden group-hover:inline-flex ml-0.5 text-linkedin-muted hover:text-linkedin-accent"
                 aria-label={`Delete ${template.name}`}
               >
                 <X size={11} />

--- a/src/components/LinkedInSearch/URLPreview.jsx
+++ b/src/components/LinkedInSearch/URLPreview.jsx
@@ -43,11 +43,18 @@ const URLPreview = ({ url, isEmpty, onShare }) => {
       const urlObj = new URL(rawUrl);
       const base = urlObj.origin + urlObj.pathname;
       const params = Array.from(urlObj.searchParams.entries());
+
+      const lineNum = (n) => (
+        <span className="select-none text-linkedin-muted/60 w-6 text-right mr-3 flex-shrink-0 font-mono-proof">
+          {String(n).padStart(2, "0")}
+        </span>
+      );
+
       if (!params.length) {
         return (
           <div className="flex">
-            <span className="select-none text-gray-600 w-8 text-right mr-3 flex-shrink-0">1</span>
-            <span className="text-gray-400">{rawUrl}</span>
+            {lineNum(1)}
+            <span className="text-linkedin-rule/60">{rawUrl}</span>
           </div>
         );
       }
@@ -55,20 +62,32 @@ const URLPreview = ({ url, isEmpty, onShare }) => {
       const lines = [];
       lines.push(
         <div key="base" className="flex">
-          <span className="select-none text-gray-600 w-8 text-right mr-3 flex-shrink-0">1</span>
-          <span className="text-gray-500">{base}?</span>
+          {lineNum(1)}
+          <span className="text-linkedin-rule">
+            {base}
+            <span className="text-linkedin-highlight">?</span>
+          </span>
         </div>
       );
 
       params.forEach(([key, value], i) => {
         lines.push(
-          <div key={key} className="flex">
-            <span className="select-none text-gray-600 w-8 text-right mr-3 flex-shrink-0">{i + 2}</span>
-            <span>
-              {i > 0 && <span className="text-gray-600">&amp;</span>}
-              <span className="text-blue-400 font-semibold">{key}</span>
-              <span className="text-gray-600">=</span>
-              <span className="text-amber-300">{decodeURIComponent(value)}</span>
+          <div key={`${key}-${value}`} className="flex items-baseline">
+            {lineNum(i + 2)}
+            <span className="break-all">
+              {i > 0 && (
+                <span className="text-linkedin-muted mr-0.5">&amp;</span>
+              )}
+              <span
+                className="text-linkedin-accent font-semibold px-0.5 rounded-[2px] animate-ink-in"
+                style={{ animationDuration: "520ms" }}
+              >
+                {key}
+              </span>
+              <span className="text-linkedin-muted">=</span>
+              <span className="text-linkedin-highlight/95">
+                {decodeURIComponent(value)}
+              </span>
             </span>
           </div>
         );
@@ -76,73 +95,85 @@ const URLPreview = ({ url, isEmpty, onShare }) => {
 
       return <div className="space-y-0.5">{lines}</div>;
     } catch {
-      return <span className="text-gray-400 break-all">{rawUrl}</span>;
+      return <span className="text-linkedin-rule/60 break-all">{rawUrl}</span>;
     }
   };
 
   if (isEmpty) {
     return (
-      <>
-        <div className="flex flex-col items-center justify-center py-12">
-          <div className="w-12 h-12 rounded-xl bg-white/[0.06] border border-white/10 flex items-center justify-center mb-4">
-            <Search size={20} className="text-gray-500" />
+      <div className="relative">
+        <span
+          aria-hidden="true"
+          className="absolute -top-2 left-4 px-1.5 font-mono-proof text-[9.5px] uppercase tracking-[0.22em] text-linkedin-highlight bg-linkedin-proof-bg z-10"
+        >
+          Proof — blank
+        </span>
+        <div className="flex flex-col items-center justify-center py-14 rounded-[10px] bg-linkedin-proof-surface border border-dashed border-linkedin-proof-rule">
+          <div className="w-11 h-11 rounded-[8px] bg-linkedin-proof-bg border border-linkedin-proof-rule flex items-center justify-center mb-4">
+            <Search size={18} className="text-linkedin-muted" />
           </div>
-          <p className="font-dm text-sm text-gray-500 text-center max-w-[200px]">
-            Start by typing a job title or pick a template
+          <p className="font-serif-display italic text-[15px] text-linkedin-rule/80 text-center max-w-[240px] leading-snug">
+            Set a keyword or pick a template
+            <br />
+            to pull your first proof.
           </p>
         </div>
-      </>
+      </div>
     );
   }
 
+  const paramCount = Array.from(new URL(url).searchParams).length;
+
   return (
     <>
-      {/* Desktop URL preview */}
+      {/* Desktop proof */}
       <div className="hidden md:block">
-        <div className="flex items-center justify-between mb-3">
-          <span className="text-[11px] font-dm font-semibold text-gray-500 uppercase tracking-[0.08em]">
-            Generated URL
+        <div className="relative">
+          <span
+            aria-hidden="true"
+            className="absolute -top-2 left-4 px-1.5 font-mono-proof text-[9.5px] uppercase tracking-[0.22em] text-linkedin-highlight bg-linkedin-proof-bg z-10"
+          >
+            Proof &middot; {paramCount}
+            {paramCount === 1 ? " mark" : " marks"}
           </span>
-          <span className="text-[11px] font-dm text-gray-600">
-            {Array.from(new URL(url).searchParams).length} params
-          </span>
-        </div>
 
-        <motion.div
-          key={url}
-          initial={{ opacity: 0.6 }}
-          animate={{ opacity: 1 }}
-          className="font-mono text-[13px] leading-relaxed p-4 bg-black/20 rounded-lg border border-white/10 overflow-x-auto no-scrollbar"
-        >
-          {renderColoredURL(url)}
-        </motion.div>
+          <motion.div
+            key={url}
+            initial={{ opacity: 0.5 }}
+            animate={{ opacity: 1 }}
+            transition={{ duration: 0.28 }}
+            className="font-mono-proof text-[12.5px] leading-[1.75] p-4 pt-5 rounded-[10px] bg-linkedin-proof-surface border border-linkedin-proof-rule overflow-x-auto no-scrollbar"
+          >
+            {renderColoredURL(url)}
+          </motion.div>
+        </div>
 
         <div className="flex flex-wrap items-center gap-2 mt-4">
           <button
             type="button"
             onClick={handleCopy}
-            className="inline-flex items-center gap-1.5 px-4 py-2 rounded-lg text-sm font-dm font-medium bg-blue-500 text-white hover:bg-blue-600 transition-all cursor-pointer focus:outline-none focus:ring-2 focus:ring-blue-400 focus:ring-offset-2 focus:ring-offset-[#1A1A2E]"
+            className="inline-flex items-center gap-1.5 px-4 py-2.5 rounded-[8px] font-sans-linkedin text-[13.5px] font-semibold bg-linkedin-accent text-linkedin-surface hover:bg-linkedin-accent-hover transition-colors cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-linkedin-highlight focus-visible:ring-offset-2 focus-visible:ring-offset-linkedin-proof-bg"
           >
             <AnimatePresence mode="wait" initial={false}>
               {copied ? (
                 <motion.span
                   key="check"
-                  initial={{ scale: 0 }}
-                  animate={{ scale: 1 }}
-                  exit={{ scale: 0 }}
+                  initial={{ scale: 0.6, opacity: 0 }}
+                  animate={{ scale: 1, opacity: 1 }}
+                  exit={{ scale: 0.6, opacity: 0 }}
                   className="inline-flex items-center gap-1.5"
                 >
-                  <Check size={14} /> Copied!
+                  <Check size={14} /> Stamped!
                 </motion.span>
               ) : (
                 <motion.span
                   key="copy"
-                  initial={{ scale: 0 }}
-                  animate={{ scale: 1 }}
-                  exit={{ scale: 0 }}
+                  initial={{ scale: 0.6, opacity: 0 }}
+                  animate={{ scale: 1, opacity: 1 }}
+                  exit={{ scale: 0.6, opacity: 0 }}
                   className="inline-flex items-center gap-1.5"
                 >
-                  <Copy size={14} /> Copy URL
+                  <Copy size={14} /> Pull a proof
                 </motion.span>
               )}
             </AnimatePresence>
@@ -150,45 +181,45 @@ const URLPreview = ({ url, isEmpty, onShare }) => {
           <button
             type="button"
             onClick={handleOpen}
-            className="inline-flex items-center gap-1.5 px-4 py-2 rounded-lg text-sm font-dm font-medium border border-white/20 text-white/80 hover:border-white/40 hover:text-white transition-all cursor-pointer focus:outline-none focus:ring-2 focus:ring-white/30 focus:ring-offset-2 focus:ring-offset-[#1A1A2E]"
+            className="inline-flex items-center gap-1.5 px-4 py-2.5 rounded-[8px] font-sans-linkedin text-[13.5px] font-medium border border-linkedin-proof-rule text-linkedin-bg/85 hover:border-linkedin-highlight hover:text-linkedin-highlight transition-colors cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-linkedin-highlight focus-visible:ring-offset-2 focus-visible:ring-offset-linkedin-proof-bg"
           >
-            <ExternalLink size={14} /> Open in LinkedIn
+            <ExternalLink size={14} /> Open on LinkedIn
           </button>
           {onShare && (
             <button
               type="button"
               onClick={handleShare}
-              className="inline-flex items-center gap-1.5 px-4 py-2 rounded-lg text-sm font-dm font-medium border border-white/20 text-white/80 hover:border-white/40 hover:text-white transition-all cursor-pointer focus:outline-none focus:ring-2 focus:ring-white/30 focus:ring-offset-2 focus:ring-offset-[#1A1A2E]"
+              className="inline-flex items-center gap-1.5 px-4 py-2.5 rounded-[8px] font-sans-linkedin text-[13.5px] font-medium border border-linkedin-proof-rule text-linkedin-bg/85 hover:border-linkedin-highlight hover:text-linkedin-highlight transition-colors cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-linkedin-highlight focus-visible:ring-offset-2 focus-visible:ring-offset-linkedin-proof-bg"
             >
               <Share2 size={14} />
-              {copiedShare ? "Link copied!" : "Share"}
+              {copiedShare ? "Link stamped" : "Share"}
             </button>
           )}
         </div>
       </div>
 
       {/* Mobile sticky bottom bar */}
-      <div className="fixed bottom-0 left-0 right-0 md:hidden bg-[#1A1A2E] border-t border-white/10 p-3 z-40">
+      <div className="fixed bottom-0 left-0 right-0 md:hidden bg-linkedin-proof-bg border-t border-linkedin-proof-rule p-3 z-40">
         <div className="flex gap-2">
           <button
             type="button"
             onClick={handleCopy}
-            className="flex-1 inline-flex items-center justify-center gap-1.5 py-2.5 rounded-lg text-sm font-dm font-medium bg-blue-500 text-white cursor-pointer"
+            className="flex-1 inline-flex items-center justify-center gap-1.5 py-2.5 rounded-[8px] font-sans-linkedin text-[13.5px] font-semibold bg-linkedin-accent text-linkedin-surface cursor-pointer"
           >
             {copied ? (
               <>
-                <Check size={14} /> Copied!
+                <Check size={14} /> Stamped!
               </>
             ) : (
               <>
-                <Copy size={14} /> Copy URL
+                <Copy size={14} /> Pull proof
               </>
             )}
           </button>
           <button
             type="button"
             onClick={handleOpen}
-            className="flex-1 inline-flex items-center justify-center gap-1.5 py-2.5 rounded-lg text-sm font-dm font-medium border border-white/20 text-white/80 cursor-pointer"
+            className="flex-1 inline-flex items-center justify-center gap-1.5 py-2.5 rounded-[8px] font-sans-linkedin text-[13.5px] font-medium border border-linkedin-proof-rule text-linkedin-bg/85 cursor-pointer"
           >
             <ExternalLink size={14} /> Open
           </button>

--- a/src/pages/_app.js
+++ b/src/pages/_app.js
@@ -3,7 +3,7 @@ import Script from "next/script";
 
 import { Provider } from "react-redux";
 import { store } from "../Redux/store";
-import { Inter, Instrument_Serif, DM_Sans } from "next/font/google";
+import { Inter, Instrument_Serif, DM_Sans, Bricolage_Grotesque, JetBrains_Mono } from "next/font/google";
 import ErrorBoundary from "@/components/common/ErrorBoundary";
 import "../styles/globals.css";
 
@@ -25,6 +25,20 @@ const dmSans = DM_Sans({
     variable: "--font-dm-sans",
 });
 
+const bricolage = Bricolage_Grotesque({
+    weight: ["400", "500", "600", "700"],
+    subsets: ["latin"],
+    variable: "--font-bricolage",
+    display: "swap",
+});
+
+const jetbrainsMono = JetBrains_Mono({
+    weight: ["400", "500", "600", "700"],
+    subsets: ["latin"],
+    variable: "--font-jetbrains-mono",
+    display: "swap",
+});
+
 const App = (props) => {
     const { Component, pageProps } = props;
     return (
@@ -36,7 +50,7 @@ const App = (props) => {
 
             <Provider store={store}>
                 <ErrorBoundary>
-                    <main className={`${inter.className} ${instrumentSerif.variable} ${dmSans.variable}`}>
+                    <main className={`${inter.className} ${instrumentSerif.variable} ${dmSans.variable} ${bricolage.variable} ${jetbrainsMono.variable}`}>
                         <Component {...pageProps} />
                     </main>
                 </ErrorBoundary>

--- a/src/pages/tools/linkedin-search.js
+++ b/src/pages/tools/linkedin-search.js
@@ -91,6 +91,13 @@ function referralFilterReducer(state, action) {
   }
 }
 
+const PAPER_GRID = {
+  backgroundImage:
+    "radial-gradient(rgba(61,51,46,0.14) 1px, transparent 1px), linear-gradient(rgba(217,207,191,0.35) 1px, transparent 1px)",
+  backgroundSize: "24px 24px, 100% 40px",
+  backgroundPosition: "0 0, 0 0",
+};
+
 export default function LinkedInSearchPage() {
   const [activeTab, setActiveTab] = useState("search");
   const [jobFilters, jobDispatch] = useReducer(jobFilterReducer, INITIAL_JOB_FILTERS);
@@ -186,13 +193,16 @@ export default function LinkedInSearchPage() {
   }, [filters, activeTab]);
 
   const tabs = [
-    { id: "search", label: "Job Search", icon: Briefcase },
-    { id: "referral", label: "Referral Finder", icon: Users },
+    { id: "search", label: "Job Search", icon: Briefcase, numeral: "01" },
+    { id: "referral", label: "Referral Finder", icon: Users, numeral: "02" },
   ];
 
   const fadeUp = shouldAnimate
-    ? { initial: { opacity: 0, y: 20 }, animate: { opacity: 1, y: 0 } }
+    ? { initial: { opacity: 0, y: 12 }, animate: { opacity: 1, y: 0 } }
     : { initial: {}, animate: {} };
+
+  const isMac =
+    typeof navigator !== "undefined" && /Mac/.test(navigator.userAgent);
 
   return (
     <>
@@ -208,92 +218,158 @@ export default function LinkedInSearchPage() {
 
       <main
         id="main-content"
-        className="min-h-screen pb-20 md:pb-12"
-        style={{ background: "radial-gradient(ellipse at 50% 0%, #EEF2FF 0%, #F9FAFB 70%)" }}
+        className="relative min-h-screen pb-20 md:pb-12 bg-linkedin-bg text-linkedin-ink overflow-hidden"
       >
+        {/* Paper grain: dot-grid + faint horizontal rule */}
+        <div
+          aria-hidden="true"
+          className="pointer-events-none absolute inset-0 opacity-70"
+          style={PAPER_GRID}
+        />
+        {/* Top torn-paper edge decoration */}
+        <svg
+          aria-hidden="true"
+          viewBox="0 0 1200 14"
+          preserveAspectRatio="none"
+          className="pointer-events-none absolute top-0 left-0 w-full h-3 text-linkedin-rule"
+        >
+          <path
+            d="M0,0 L0,8 L40,4 L90,10 L140,5 L200,9 L260,3 L320,8 L390,5 L460,10 L530,4 L600,9 L670,5 L740,10 L820,4 L900,9 L970,5 L1050,10 L1120,4 L1200,8 L1200,0 Z"
+            fill="currentColor"
+            opacity="0.55"
+          />
+        </svg>
+        {/* Soft atmospheric vignette at top center */}
+        <div
+          aria-hidden="true"
+          className="pointer-events-none absolute top-0 left-1/2 -translate-x-1/2 w-[900px] h-[420px] opacity-60"
+          style={{
+            background:
+              "radial-gradient(ellipse at 50% 0%, rgba(201,155,60,0.18) 0%, rgba(199,91,63,0.05) 40%, transparent 70%)",
+          }}
+        />
+
         {/* Hero */}
-        <div className="max-w-content mx-auto px-4 lg:px-6 pt-24 sm:pt-28">
-          <div className="max-w-[680px] mx-auto text-center mb-10">
-            <motion.p
+        <div className="relative max-w-content mx-auto px-4 lg:px-6 pt-24 sm:pt-28">
+          <div className="max-w-[720px] mx-auto text-center mb-12">
+            <motion.div
               {...fadeUp}
-              transition={{ duration: 0.3 }}
-              className="text-[11px] font-dm font-semibold uppercase tracking-[0.1em] text-primary mb-5"
+              transition={{ duration: 0.32 }}
+              className="inline-flex items-center gap-2 mb-6"
             >
-              Smart Search Builder
-            </motion.p>
+              <span
+                aria-hidden="true"
+                className="inline-flex h-5 w-5 items-center justify-center rounded-[3px] bg-linkedin-accent text-linkedin-surface font-mono-proof text-[10px] font-bold leading-none shadow-letterpress-inset"
+              >
+                ¶
+              </span>
+              <span className="text-[11px] font-mono-proof font-semibold uppercase tracking-[0.22em] text-linkedin-accent">
+                Press &amp; Proof &middot; Issue 04
+              </span>
+            </motion.div>
+
             <motion.h1
               {...fadeUp}
-              transition={{ duration: 0.3, delay: 0.05 }}
-              className="font-serif-display font-normal text-text-primary mb-5"
-              style={{ fontSize: "clamp(2.25rem, 5vw, 3rem)", lineHeight: 1.1, letterSpacing: "-0.02em" }}
+              transition={{ duration: 0.36, delay: 0.06 }}
+              className="font-serif-display font-normal text-linkedin-ink mb-5 tracking-tight"
+              style={{
+                fontSize: "clamp(2.5rem, 6vw, 4rem)",
+                lineHeight: 1.02,
+                letterSpacing: "-0.025em",
+              }}
             >
-              Build your perfect
+              Typeset your <em className="text-linkedin-accent italic">perfect</em>
               <br />
-              LinkedIn search.
+              LinkedIn <em className="italic text-linkedin-ink-soft">search</em>,
+              <br />
+              one param at a time.
             </motion.h1>
+
             <motion.p
               {...fadeUp}
-              transition={{ duration: 0.3, delay: 0.15 }}
-              className="text-base font-dm text-gray-500 max-w-[480px] mx-auto mb-4 leading-relaxed"
+              transition={{ duration: 0.32, delay: 0.16 }}
+              className="font-sans-linkedin text-[1.0625rem] text-linkedin-ink-soft max-w-[520px] mx-auto mb-6 leading-relaxed"
             >
-              Craft optimized search URLs with smart filters.
-              No sign-in required.
+              A letterpress URL builder. Pick keywords, ink the filters, pull a clean
+              proof — then take it to LinkedIn. No sign-in. No tracking.
             </motion.p>
-            <motion.p
+
+            <motion.div
               {...fadeUp}
-              transition={{ duration: 0.3, delay: 0.25 }}
-              className="text-xs font-dm text-gray-400"
+              transition={{ duration: 0.32, delay: 0.24 }}
+              className="inline-flex items-center gap-3 font-mono-proof text-[11px] text-linkedin-ink-soft"
             >
-              <kbd className="px-1.5 py-0.5 rounded border border-gray-200 bg-white text-[10px] font-mono text-gray-500">
-                {typeof navigator !== "undefined" && /Mac/.test(navigator.userAgent) ? "⌘" : "Ctrl"}+K
-              </kbd>{" "}
-              to focus search &middot;{" "}
-              <kbd className="px-1.5 py-0.5 rounded border border-gray-200 bg-white text-[10px] font-mono text-gray-500">
-                {typeof navigator !== "undefined" && /Mac/.test(navigator.userAgent) ? "⌘" : "Ctrl"}+⇧+C
-              </kbd>{" "}
-              to copy URL
-            </motion.p>
+              <span className="inline-flex items-center gap-1.5">
+                <kbd className="px-1.5 py-0.5 rounded-[4px] bg-linkedin-surface border border-linkedin-rule shadow-letterpress-inset text-linkedin-ink">
+                  {isMac ? "⌘" : "Ctrl"}
+                </kbd>
+                <kbd className="px-1.5 py-0.5 rounded-[4px] bg-linkedin-surface border border-linkedin-rule shadow-letterpress-inset text-linkedin-ink">
+                  K
+                </kbd>
+                <span className="text-linkedin-muted">focus keywords</span>
+              </span>
+              <span aria-hidden="true" className="text-linkedin-rule">
+                /
+              </span>
+              <span className="inline-flex items-center gap-1.5">
+                <kbd className="px-1.5 py-0.5 rounded-[4px] bg-linkedin-surface border border-linkedin-rule shadow-letterpress-inset text-linkedin-ink">
+                  {isMac ? "⌘" : "Ctrl"}
+                </kbd>
+                <kbd className="px-1.5 py-0.5 rounded-[4px] bg-linkedin-surface border border-linkedin-rule shadow-letterpress-inset text-linkedin-ink">
+                  ⇧
+                </kbd>
+                <kbd className="px-1.5 py-0.5 rounded-[4px] bg-linkedin-surface border border-linkedin-rule shadow-letterpress-inset text-linkedin-ink">
+                  C
+                </kbd>
+                <span className="text-linkedin-muted">pull a proof</span>
+              </span>
+            </motion.div>
           </div>
         </div>
 
         {/* Two-column workspace */}
         <motion.div
           {...fadeUp}
-          transition={{ duration: 0.3, delay: 0.3 }}
-          className="max-w-content mx-auto px-4 lg:px-6"
+          transition={{ duration: 0.4, delay: 0.32 }}
+          className="relative max-w-content mx-auto px-4 lg:px-6"
         >
-          <div className="grid grid-cols-1 lg:grid-cols-[1fr_400px] gap-6">
-            {/* Left Column: Filters */}
+          <div className="grid grid-cols-1 lg:grid-cols-[1fr_420px] gap-6 lg:gap-8">
+            {/* Left Column: Composing stick */}
             <div>
-              {/* Tabs — underline style */}
-              <div className="flex gap-0 border-b border-gray-200 mb-5">
-                {tabs.map((tab) => (
-                  <button
-                    key={tab.id}
-                    type="button"
-                    onClick={() => setActiveTab(tab.id)}
-                    className={`relative flex items-center gap-2 px-4 py-3 text-sm font-dm font-semibold transition-colors cursor-pointer focus:outline-none ${
-                      activeTab === tab.id
-                        ? "text-primary"
-                        : "text-gray-400 hover:text-gray-700"
-                    }`}
-                  >
-                    <tab.icon size={15} />
-                    {tab.label}
-                    {activeTab === tab.id && (
-                      <motion.div
-                        layoutId="tab-underline"
-                        className="absolute bottom-0 left-0 right-0 h-[2px] bg-primary"
-                        transition={{ type: "spring", bounce: 0.15, duration: 0.4 }}
-                      />
-                    )}
-                  </button>
-                ))}
+              {/* Tabs — typeset numerals + terracotta underline */}
+              <div className="relative mb-6">
+                <div className="flex gap-0 border-b border-linkedin-rule">
+                  {tabs.map((tab) => (
+                    <button
+                      key={tab.id}
+                      type="button"
+                      onClick={() => setActiveTab(tab.id)}
+                      className={`relative flex items-end gap-2 px-4 sm:px-5 pb-3 pt-2 font-sans-linkedin font-semibold transition-colors cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-linkedin-accent focus-visible:ring-offset-2 focus-visible:ring-offset-linkedin-bg ${
+                        activeTab === tab.id
+                          ? "text-linkedin-ink"
+                          : "text-linkedin-muted hover:text-linkedin-ink-soft"
+                      }`}
+                    >
+                      <span className="font-mono-proof text-[11px] tracking-[0.08em] opacity-70">
+                        {tab.numeral}
+                      </span>
+                      <tab.icon size={14} className="mb-[1px]" />
+                      <span className="text-[14px]">{tab.label}</span>
+                      {activeTab === tab.id && (
+                        <motion.div
+                          layoutId="tab-underline"
+                          className="absolute -bottom-[1px] left-0 right-0 h-[2px] bg-linkedin-accent"
+                          transition={{ type: "spring", bounce: 0.2, duration: 0.45 }}
+                        />
+                      )}
+                    </button>
+                  ))}
+                </div>
               </div>
 
               {/* Templates (job search only) */}
               {activeTab === "search" && (
-                <div className="mb-4">
+                <div className="mb-5">
                   <TemplateBar
                     templates={allTemplates}
                     onApply={handleApplyTemplate}
@@ -306,7 +382,7 @@ export default function LinkedInSearchPage() {
 
               {/* Active Filters */}
               {!isEmpty && (
-                <div className="mb-4">
+                <div className="mb-5">
                   <ActiveFiltersBar
                     filters={filters}
                     tab={activeTab}
@@ -326,40 +402,62 @@ export default function LinkedInSearchPage() {
               )}
             </div>
 
-            {/* Right Column: Dark Preview Panel */}
-            <motion.div
+            {/* Right Column: Proof press */}
+            <motion.aside
               {...(shouldAnimate
-                ? { initial: { opacity: 0, y: 20, scale: 0.98 }, animate: { opacity: 1, y: 0, scale: 1 } }
-                : { initial: {}, animate: {} }
-              )}
-              transition={{ duration: 0.35, delay: 0.35 }}
-              className="lg:sticky lg:top-20 lg:self-start rounded-2xl p-6 space-y-5"
-              style={{ background: "#1A1A2E" }}
+                ? {
+                    initial: { opacity: 0, y: 16 },
+                    animate: { opacity: 1, y: 0 },
+                  }
+                : { initial: {}, animate: {} })}
+              transition={{ duration: 0.42, delay: 0.4 }}
+              className="lg:sticky lg:top-20 lg:self-start"
             >
-              {/* Summary */}
-              <HumanReadableSummary filters={filters} tab={activeTab} />
+              <div className="relative rounded-[14px] bg-linkedin-proof-bg text-linkedin-bg shadow-proof-panel border border-linkedin-proof-rule overflow-hidden">
+                {/* Proof panel masthead */}
+                <div className="flex items-center justify-between px-5 py-3 border-b border-linkedin-proof-rule bg-gradient-to-b from-[#221B18] to-[#1A1614]">
+                  <div className="flex items-center gap-2">
+                    <span className="flex gap-1" aria-hidden="true">
+                      <span className="h-2 w-2 rounded-full bg-linkedin-accent/80" />
+                      <span className="h-2 w-2 rounded-full bg-linkedin-highlight/70" />
+                      <span className="h-2 w-2 rounded-full bg-linkedin-rule/40" />
+                    </span>
+                    <span className="font-mono-proof text-[10px] uppercase tracking-[0.22em] text-linkedin-rule/80">
+                      Proof Press
+                    </span>
+                  </div>
+                  <span className="font-mono-proof text-[10px] uppercase tracking-[0.22em] text-linkedin-muted">
+                    {activeTab === "search" ? "Plate · 01" : "Plate · 02"}
+                  </span>
+                </div>
 
-              {/* URL Preview */}
-              <URLPreview url={url} isEmpty={isEmpty} onShare={isEmpty ? null : handleShare} />
+                <div className="p-5 space-y-5">
+                  <HumanReadableSummary filters={filters} tab={activeTab} />
+                  <URLPreview url={url} isEmpty={isEmpty} onShare={isEmpty ? null : handleShare} />
 
-              {/* Cross-link to CareersAt.Tech jobs */}
-              <div className="p-4 rounded-lg bg-white/[0.06] border border-white/10 text-center">
-                <p className="text-sm font-dm text-gray-400 mb-2">
-                  Also check CareersAt.Tech for verified listings
-                </p>
-                <Link
-                  href="/jobs"
-                  className="inline-flex items-center gap-1.5 text-sm font-dm font-medium text-blue-400 hover:text-blue-300 transition-colors"
-                >
-                  Browse jobs <ArrowRight size={14} />
-                </Link>
+                  {/* Cross-link */}
+                  <div className="px-4 py-3 rounded-[10px] bg-linkedin-proof-surface border border-linkedin-proof-rule text-center">
+                    <p className="font-sans-linkedin text-[13px] text-linkedin-muted mb-1.5">
+                      Also browse verified listings at CareersAt.Tech
+                    </p>
+                    <Link
+                      href="/jobs"
+                      className="inline-flex items-center gap-1.5 font-sans-linkedin text-[13px] font-medium text-linkedin-highlight hover:text-linkedin-bg transition-colors group"
+                    >
+                      Open the job board
+                      <ArrowRight
+                        size={13}
+                        className="transition-transform group-hover:translate-x-0.5"
+                      />
+                    </Link>
+                  </div>
+
+                  <p className="text-center font-mono-proof text-[10px] uppercase tracking-[0.22em] text-linkedin-muted">
+                    Not affiliated with LinkedIn · URL builder only · no data collected
+                  </p>
+                </div>
               </div>
-
-              {/* Disclaimer */}
-              <p className="text-center text-[11px] font-dm text-gray-600">
-                Not affiliated with LinkedIn Corporation. This tool generates URLs only — no data is collected.
-              </p>
-            </motion.div>
+            </motion.aside>
           </div>
         </motion.div>
       </main>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -36,20 +36,29 @@ module.exports = {
         },
         whatsapp: "#25D366",
         linkedin: {
-          bg: "#F7F4EF",
+          bg: "#F4EEE4",
+          surface: "#FCF8F1",
           accent: "#C75B3F",
           "accent-hover": "#B5492F",
           "accent-light": "#FFF5F2",
           charcoal: "#2C2C2C",
+          ink: "#1A1614",
+          "ink-soft": "#3D332E",
           border: "#E5E0D8",
-          surface: "#FFFFFF",
+          rule: "#D9CFBF",
           muted: "#8A8580",
+          highlight: "#C99B3C",
+          "proof-bg": "#1A1614",
+          "proof-surface": "#2A2320",
+          "proof-rule": "#3D332E",
         },
       },
       fontFamily: {
         sans: ["Inter", "Noto Sans", "system-ui", "-apple-system", "sans-serif"],
         "serif-display": ["var(--font-instrument-serif)", "Georgia", "serif"],
         dm: ["var(--font-dm-sans)", "Inter", "sans-serif"],
+        "sans-linkedin": ["var(--font-bricolage)", "system-ui", "sans-serif"],
+        "mono-proof": ["var(--font-jetbrains-mono)", "ui-monospace", "SFMono-Regular", "monospace"],
       },
       fontSize: {
         hero: ["3rem", { lineHeight: "1.1", letterSpacing: "-0.025em", fontWeight: "700" }],
@@ -80,6 +89,14 @@ module.exports = {
         "search-focus": "0 0 0 3px rgba(37,99,235,0.1)",
         "linkedin-card": "0 2px 8px rgba(0,0,0,0.06), 0 1px 2px rgba(0,0,0,0.04)",
         "linkedin-card-hover": "0 8px 24px rgba(0,0,0,0.08), 0 2px 8px rgba(0,0,0,0.04)",
+        letterpress:
+          "0 1px 0 rgba(26,22,20,0.04), 0 8px 20px -12px rgba(26,22,20,0.12)",
+        "letterpress-hover":
+          "0 1px 0 rgba(26,22,20,0.06), 0 14px 28px -14px rgba(26,22,20,0.22)",
+        "letterpress-inset":
+          "inset 0 -1px 0 rgba(26,22,20,0.15), 0 1px 0 rgba(255,255,255,0.6)",
+        "proof-panel":
+          "0 30px 60px -30px rgba(26,22,20,0.45), 0 12px 24px -18px rgba(26,22,20,0.25)",
       },
       keyframes: {
         "fade-in-up": {
@@ -94,11 +111,28 @@ module.exports = {
           "0%": { transform: "translateX(0%)" },
           "100%": { transform: "translateX(-50%)" },
         },
+        "ink-in": {
+          "0%": { backgroundColor: "rgba(201,155,60,0.38)" },
+          "70%": { backgroundColor: "rgba(201,155,60,0.18)" },
+          "100%": { backgroundColor: "transparent" },
+        },
+        "press-reveal": {
+          "0%": { opacity: "0", transform: "translateY(6px)" },
+          "100%": { opacity: "1", transform: "translateY(0)" },
+        },
+        "stamp-bloom": {
+          "0%": { transform: "scale(0.8)", opacity: "0" },
+          "60%": { transform: "scale(1.04)", opacity: "1" },
+          "100%": { transform: "scale(1)", opacity: "1" },
+        },
       },
       animation: {
         "fade-in-up": "fade-in-up 0.3s ease-out forwards",
         shimmer: "shimmer 1.5s ease-in-out infinite",
         marquee: "marquee 30s linear infinite",
+        "ink-in": "ink-in 520ms ease-out",
+        "press-reveal": "press-reveal 360ms ease-out forwards",
+        "stamp-bloom": "stamp-bloom 220ms ease-out",
       },
     },
   },


### PR DESCRIPTION
## Summary

Recasts `/tools/linkedin-search` as a typesetter's workbench — a contextually-designed aesthetic for a tool that builds URLs (i.e. whose output is typography).

- **Palette:** warm cream paper `#F4EEE4`, terracotta ink `#C75B3F`, aged-gold highlight `#C99B3C`, deep warm ink `#1A1614` for the dark proof panel. Unlocks the previously-unused `linkedin.*` tokens in `tailwind.config.js`.
- **Typography:** Instrument Serif (display, italic for accents), Bricolage Grotesque (UI), JetBrains Mono (URL proof, keyboard caps, stamp marks). No Inter or DM Sans on this page.
- **Atmosphere:** dot-grid + horizontal-rule paper texture, torn-paper top edge (inline SVG), warm vignette glow — replaces the old blue radial gradient.
- **Motion:** staggered press-reveal entrance, stamp-bloom on chip selection, ink-in highlight flash on URL param changes, tab underline via Framer `layoutId`. All honor `prefers-reduced-motion`.
- **Voice overlay** (microcopy only): "composing stick", "proof press", "pull a proof", "stamped!", "colophon", "imprint" — scoped to this page.

All logic preserved: reducers, `url-builder.js`, `useLinkedInURL`, `useTemplates`, hash-share, `⌘K` / `⌘⇧C` shortcuts, a11y focus rings, mobile sticky bottom bar.

## Design system

- `DESIGN_SYSTEM.md` §17.4 rewritten as the first **named sub-system** ("Press & Proof"). It documents the palette override, typography, shadows, atmosphere, motion, voice, and scoping rules — other tool pages continue to follow the main system unchanged.
- §19 Don't amended to permit named sub-systems (was previously a hard "no page-specific palettes").
- Changelog updated.

## Files

- `tailwind.config.js` — extend `linkedin.*` tokens (ink, rule, highlight, proof-bg/surface/rule), add `font-sans-linkedin` + `font-mono-proof`, `shadow-letterpress*`, `shadow-proof-panel`, `animation-ink-in`, `animation-press-reveal`, `animation-stamp-bloom`
- `src/pages/_app.js` — load `Bricolage_Grotesque` + `JetBrains_Mono` via `next/font/google` as CSS variables (additive; other pages unaffected)
- `src/pages/tools/linkedin-search.js` — new hero, paper atmosphere, proof-press panel with masthead
- `src/components/LinkedInSearch/*.jsx` — all 8 components restyled: SearchBuilder, ReferralFinder, FilterChip, FilterSection (dashed rules, terracotta icon tiles), URLPreview (line-numbered proof + ink-in flash), HumanReadableSummary (serif italic reading-proof), TemplateBar, ActiveFiltersBar
- `DESIGN_SYSTEM.md` — §17.4 rewrite + §19 exception + changelog

## Test plan

- [ ] `npm run dev` → `http://localhost:3000/tools/linkedin-search`
- [ ] Visual: warm cream paper, dot-grid, torn-paper top edge, terracotta tab underline, Instrument Serif italic accents in headline
- [ ] Type a keyword → URL proof panel shows param with brief gold ink-in flash
- [ ] Toggle chips → terracotta stamp-bloom dot appears; chip shows inked-stamp fill
- [ ] Switch tabs → numeral prefix (01 / 02) + terracotta underline glides via `layoutId`
- [ ] Copy button reads "Pull a proof" → "Stamped!" on click
- [ ] `⌘K` focuses keywords; `⌘⇧C` copies URL
- [ ] Templates ("Standing type · quick plates") scroll horizontally; "Save plate" input works
- [ ] Referral tab → company/role/connection-degree/location fields; "Colophon · how it works" accordion
- [ ] `prefers-reduced-motion: reduce` (DevTools → Rendering) → entrance animations disabled
- [ ] Mobile (375px): single column, sticky bottom bar with Pull proof + Open
- [ ] 200% zoom → no overflow, hit-targets ≥ 44px
- [ ] Lighthouse a11y → terracotta-on-cream and highlight-on-ink meet WCAG AA
- [ ] Other pages (`/jobs`, `/tools`) visually unchanged — font/palette overrides are scoped to this page

https://claude.ai/code/session_013a1KrJ2qfMdrc2P2cvEQ4G