### PR TITLE
Remove jdpage check so all jobs redirect to detail page

### DIFF
--- a/src/components/Jobcard/Jobcard.jsx
+++ b/src/components/Jobcard/Jobcard.jsx
@@ -16,23 +16,20 @@ import { generateSlugFromrole, generateRandomImpression } from "@/Helpers/jobdet
 import { DEFAULT_COMPANY_LOGO } from "@/Helpers/config";
 
 const Jobcard = (props) => {
-    const { title, role, imagePath, jobtype, location, experience, jdpage, totalclick, id, link, companyName, createdAt, company } = props.data;
+    const { title, role, imagePath, jobtype, location, experience, totalclick, id, link, companyName, createdAt, company } = props.data;
 
     const [jobcardClicked, setJobcardClicked] = useState(false);
 
     const titleforShare = generateSlugFromrole(title);
     const impressionClick = generateRandomImpression(totalclick)
 
-    // redirect to job detail page when jdpage is true
     const redirectToJobdetailPage = () => {
         Router.push(`/${titleforShare}/${id}`);
     };
 
     // when mouse hovered over a job card prefetch the job details
     const onMouseEnter = () => {
-        if (jdpage === "true") {
-            Router.prefetch(`/${titleforShare}/${id}`);
-        }
+        Router.prefetch(`/${titleforShare}/${id}`);
     };
 
     // return company logo or default placeholder
@@ -46,16 +43,15 @@ const Jobcard = (props) => {
 
     // handle job card click
     const handleJobCardClick = () => {
-        // if job description present open jd page
-        if (jdpage === "true") {
-            setJobcardClicked(true);
-            redirectToJobdetailPage();
-        }
-        // open job details in careers page in new tab
-        if (jdpage === "false" || jobtype === "promo") {
+        // open external link for promo jobs
+        if (jobtype === "promo") {
             window.open(link);
             countClickinJd(id);
+            return;
         }
+        // redirect to job detail page for all other jobs
+        setJobcardClicked(true);
+        redirectToJobdetailPage();
     };
 
     return (


### PR DESCRIPTION
## Summary
- Remove the `jdpage === "true"` check in `Jobcard` so every job card click redirects to the in-app job detail page
- Prefetch the detail route on every card hover (previously gated on `jdpage`)
- Preserve the existing `jobtype === "promo"` behavior: promo cards still open the external link and log a click

## Test plan
- [ ] Job listing page: click a job with `jdpage === "false"` — should navigate to `/{slug}/{id}` instead of opening the external link
- [ ] Job listing page: click a job with `jdpage === "true"` — should still navigate to `/{slug}/{id}`
- [ ] Promo card: click still opens the external link in a new tab and fires `countClickinJd`
- [ ] Hover over a job card prefetches the detail route
